### PR TITLE
Initial stub for an \annotate function

### DIFF
--- a/editorial-tools/README.md
+++ b/editorial-tools/README.md
@@ -1,0 +1,4 @@
+Editorial Tools
+---------------
+
+This file/commit is a stub to add/move (improved) tools from our private lib to the snippets repo.

--- a/editorial-tools/annotate/definitions.ily
+++ b/editorial-tools/annotate/definitions.ily
@@ -57,14 +57,30 @@
 
 \version "2.16.2"
 
+#(define (create-props-alist l)
+   ;; takes the list of context-mods and creates
+   ;; an alist with type/content pairs
+   (cond ((null? l)
+          '())
+         (else
+          (cons (cdr (car l)) (create-props-alist (cdr l))))))
+
 annotate = 
 #(define-music-function (parser location properties item)
    (ly:context-mod? symbol-list-or-music?)
    ;; annotates a musical object for use with lilypond-doc
-   
-   ; Dummy coloring
+   (let ((props (create-props-alist (ly:get-context-mods properties))))
+     
+     (newline)
+     (display (assoc 'message props))
+     (newline)
+     (newline)
+     (display "props: ")
+     (display props)
+     (newline)
+
+     ; Dummy coloring
      #{ 
        \once \tweak color #magenta #item
      #}
-   )
-
+   ))

--- a/editorial-tools/annotate/definitions.ily
+++ b/editorial-tools/annotate/definitions.ily
@@ -1,0 +1,57 @@
+\version "2.16.2" % absolutely necessary!
+
+\header {
+  snippet-title = "Annotate grobs"
+  snippet-author = "Urs Liska"
+  snippet-description = \markup {
+    Add annotations to arbitrary grobs in an input file.
+    These annotations can be used to 
+    - issue compiler messages,
+    - write annotations to external files,
+    - color annotated grobs,
+    - possibly print annotations on top of the score.
+    
+    The use of context mods as argument makes it very straightforward
+    to enter annotations, see the enclosed example file for how
+    it works.
+    
+  }
+  status = "started"
+  todo = \markup {
+    Currently this is only a stub allowing for entering annotations
+    without causing compiler warnings. As a placeholder affected grobs
+    are printed magenta. Any further functionality has to be implemented yet.
+    
+    - The coloring through tweak doesn't seem to be "\once" currently.
+    
+    - What is lacking is any kind of checking against a list of predefined
+      message types, formats etc.
+    
+    - Find a way to "enclose" images as links (maybe kind of Markdown style?)
+    - Find a way to insert score examples in the message.
+    
+    - For further discussion see 
+      https://github.com/openlilylib/lilypond-doc/wiki/Documenting-musical-content
+  }
+
+  % add comma-separated tags to make searching more effective:
+  tags = "documentation, annotations, editorial tools"
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+% here goes the snippet: %
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\version "2.17.18"
+
+annotate = 
+#(define-music-function (parser location properties item)
+   (ly:context-mod? symbol-list-or-music?)
+   ;; annotates a musical object for use with lilypond-doc
+   
+   ; Dummy coloring
+     #{ 
+       \once \tweak color #magenta #item
+     #}
+   )
+

--- a/editorial-tools/annotate/definitions.ily
+++ b/editorial-tools/annotate/definitions.ily
@@ -15,6 +15,13 @@
     to enter annotations, see the enclosed example file for how
     it works.
     
+    Calling syntax:
+    "\annotate \with { [list of expressions] } grobname"
+    If you leave out the grobname the function will implicitly
+    annotate the next notehead.
+    You can also use postfix notation to annotate individual
+    grobs like with the "\tweak" command.
+    
   }
   status = "started"
   todo = \markup {
@@ -22,13 +29,19 @@
     without causing compiler warnings. As a placeholder affected grobs
     are printed magenta. Any further functionality has to be implemented yet.
     
-    - The coloring through tweak doesn't seem to be "\once" currently.
-    
-    - What is lacking is any kind of checking against a list of predefined
-      message types, formats etc.
+    - Determine current musical moment as well as current position
+      in the source file for point-and-click links.
+    - There should be a set of predefined annotation types (e.g.
+      "todo", "critical remark", "discussion" etc.). These may behave
+      differently, e.g. color the output differently or export information
+      differently formatted.
+    - Apart from that, arbitrary annotation types can be entered with some
+      predefined response, e.g. output sorted lists for each detected type.
     
     - Find a way to "enclose" images as links (maybe kind of Markdown style?)
-    - Find a way to insert score examples in the message.
+    - Find a way to insert score examples in the message.)
+      This could either be done by including LilyPond code (would be best)
+      or by linking to external source files and/or image/pdf scores.
     
     - For further discussion see 
       https://github.com/openlilylib/lilypond-doc/wiki/Documenting-musical-content

--- a/editorial-tools/annotate/definitions.ily
+++ b/editorial-tools/annotate/definitions.ily
@@ -55,7 +55,7 @@
 % here goes the snippet: %
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\version "2.17.18"
+\version "2.16.2"
 
 annotate = 
 #(define-music-function (parser location properties item)

--- a/editorial-tools/annotate/examples.ly
+++ b/editorial-tools/annotate/examples.ly
@@ -1,7 +1,13 @@
 % Usage examples for \annotate
 
+% Real-world include command:
 % \include "editorial-tools/annotate/definitions.ily"
 \include "definitions.ily"
+
+\header {
+  title = "Annotate grobs"
+  subtitle = "Currently this only colors them magenta"
+}
 
 \relative g' {
   % default call with specified grob
@@ -14,7 +20,7 @@
     message = "Tenuto added as in Vc. 2"
   }
   Script
-  g1-- |
+  g1-- -\markup "Explicitly annotate Script" |
   
   % default call without specified grob (defaults to NoteHead (?))
   \annotate \with {
@@ -22,14 +28,14 @@
     source = "MS2"
     message = "Ms. 2: b flat"
   }
-  a4 b 
+  a4 ~  ^\markup "Implicitly annotate notehead, tie is not affected" a b 
   
      % postfix call
      c-\annotate \with {
       type = "todo-engraving"
       message = "Improve tie engraving"
     }
-    ~ 
+    ~ -\markup "Postfix annotation"
     c 
-    d ~ d e2-- 
+    d ~ d e-- 
 }

--- a/editorial-tools/annotate/examples.ly
+++ b/editorial-tools/annotate/examples.ly
@@ -1,5 +1,7 @@
 % Usage examples for \annotate
 
+\version "2.16.2"
+
 % Real-world include command:
 % \include "editorial-tools/annotate/definitions.ily"
 \include "definitions.ily"
@@ -12,7 +14,7 @@
 \relative g' {
   % default call with specified grob
   \annotate \with {
-    type = "critical remark"
+    type = "critical-remark"
     context = "vc1"
     author = "Urs Liska"
     date = "2013-06-06"

--- a/editorial-tools/annotate/examples.ly
+++ b/editorial-tools/annotate/examples.ly
@@ -1,0 +1,35 @@
+% Usage examples for \annotate
+
+% \include "editorial-tools/annotate/definitions.ily"
+\include "definitions.ily"
+
+\relative g' {
+  % default call with specified grob
+  \annotate \with {
+    type = "critical remark"
+    context = "vc1"
+    author = "Urs Liska"
+    date = "2013-06-06"
+    format = "plain"
+    message = "Tenuto added as in Vc. 2"
+  }
+  Script
+  g1-- |
+  
+  % default call without specified grob (defaults to NoteHead (?))
+  \annotate \with {
+    type = "question"
+    source = "MS2"
+    message = "Ms. 2: b flat"
+  }
+  a4 b 
+  
+     % postfix call
+     c-\annotate \with {
+      type = "todo-engraving"
+      message = "Improve tie engraving"
+    }
+    ~ 
+    c 
+    d ~ d e2-- 
+}


### PR DESCRIPTION
In its current form the function simply offers a signature and colors an affected grob magenta.

The idea behind it is to annotate music directly in the music input file.
One will be able to enter a set of different preset annotation types and also arbitrary ones. The presets should have some predefined behaviour while the arbitrary ones just get output, leaving it to the user to make use of them.

The idea is to (optionally)
- write messsages to the command line
- write entries to an external file (like latex's toc files)
- highlight (color) grobs
- (maybe) print annotations on top of the score (once it will be able to "print" to layers.

Please comment on the signature, add possible use cases, ideas for recognized options.

See [this file](https://bitbucket.org/beautifulscores/das-trunkne-lied/src/bb4e5ca2256c900c140480462054854b631ff23e/parts/violoncello/05.ily?at=vc-modify-compile-segment) as a (preliminary) real-world example file.
