### PR TITLE
New snippets for interval brackets and vertical spacing

### DIFF
--- a/input-shorthands/vertical-spacing/definitions.ily
+++ b/input-shorthands/vertical-spacing/definitions.ily
@@ -13,11 +13,12 @@
 }
 
 % this is intended to return the scheme construct with the given values:
-simplespace = #(define-scheme-function
-     (parser location bdist mdist padd stret)
-     (number? number? number? number?)
-     `((basic-distance . ,bdist)
-       (minimum-distance . ,mdist)
-       (padding . ,padd)
-       (stretchability . ,stret))
-     )
+simplespace =
+#(define-scheme-function
+  (parser location bdist mdist padd stret)
+  (number? number? number? number?)
+  `((basic-distance . ,bdist)
+    (minimum-distance . ,mdist)
+    (padding . ,padd)
+    (stretchability . ,stret))
+  )

--- a/input-shorthands/vertical-spacing/definitions.ily
+++ b/input-shorthands/vertical-spacing/definitions.ily
@@ -1,0 +1,23 @@
+\version "2.16.2"
+
+\header {
+  snippet-title = "Shorthand for Setting Vertical Spacing"
+  snippet-author = "Joram Berger"
+  snippet-source = ""
+  snippet-description = \markup {
+    This snippet provides the simplespace function. Usage:
+    "\simplespace basic-distance min-distance padding stretchability"
+  }
+  tags = "vertical spacing, shorthand, distance"
+  status = "ready"
+}
+
+% this is intended to return the scheme construct with the given values:
+simplespace = #(define-scheme-function
+     (parser location bdist mdist padd stret)
+     (number? number? number? number?)
+     `((basic-distance . ,bdist)
+       (minimum-distance . ,mdist)
+       (padding . ,padd)
+       (stretchability . ,stret))
+     )

--- a/input-shorthands/vertical-spacing/example.ly
+++ b/input-shorthands/vertical-spacing/example.ly
@@ -1,0 +1,13 @@
+\version "2.16.2"
+\include "definitions.ily"
+
+\markup \bold \huge "Vertical Spacing"
+
+\paper {
+  % instead of a large construction, these four values
+  % define the vertical spacing:
+  system-system-spacing = \simplespace 25 2 3 60
+  annotate-spacing = ##t  % only for demonstration
+}
+
+{ c''1 \break c''1 }

--- a/notation-snippets/interval-brackets/definitions.ily
+++ b/notation-snippets/interval-brackets/definitions.ily
@@ -75,7 +75,7 @@
 #(define three-semi-tone-gliss
   (elbowed-glissando '((0 . -0.35) (0.5 . -0.7) (1.0 . -0.2) (1.0 . 0.15))))
 
-scaleSettings = {
+intervalBracketsOn = {
   \override Glissando #'Y-offset = #-1
   \override Glissando #'thickness = #0.2
   \override Glissando #'bound-details =
@@ -83,7 +83,7 @@ scaleSettings = {
         (right   (end-on-accidental . #f) (padding . 0.2)))
 }
 
-revertScaleSettings = {
+intervalBracketsOff = {
   \revert Glissando #'Y-offset
   \revert Glissando #'thickness
   \revert Glissando #'bound-details

--- a/notation-snippets/interval-brackets/definitions.ily
+++ b/notation-snippets/interval-brackets/definitions.ily
@@ -1,0 +1,112 @@
+\version "2.16.2"
+
+\header {
+  snippet-title = "Interval Brackets for Scales"
+  snippet-author = "Joram Berger and Thomas Morley"
+  snippet-source = "http://lists.gnu.org/archive/html/lilypond-user/2013-03/msg00753.html"
+  snippet-description = \markup {
+    This snippet provides brackets for semitones, tones and
+    one and a half tones for scales as used mostly for
+    educational purposes. The functionality is turned on via
+    "\scaleSettings" and turned off via "\revertScaleSettings".
+    Three brackets are provided: "\semitone", "\tone" and
+    "\threesemitone".
+  }
+  tags = "scale, interval, semitone, bracket"
+  status = "ready"
+}
+
+%{
+  This can be further improved with ideas in the mentioned thread
+  and otherwise. Currently it only works for rising scales.
+%}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+% here goes the snippet: %
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+#(define ((elbowed-glissando coords) grob)
+
+ (define (pair-to-list pair)
+    (list (car pair) (cdr pair)))
+
+ (define (normalize-coords goods x y)
+   (map
+     (lambda (coord)
+       (cons (* x (car coord)) (* y (cdr coord))))
+     goods))
+
+ (define (my-c-p-s points thick)
+   (make-connected-path-stencil
+     points
+     thick
+     1.0
+     1.0
+     #f
+     #f))
+
+; outer let to trigger suicide
+ (let ((sten (ly:line-spanner::print grob)))
+   (if (grob::is-live? grob)
+       (let* ((thick (ly:grob-property grob 'thickness 0.1))
+              (xex (ly:stencil-extent sten X))
+              (lenx (interval-length xex))
+              (yex (ly:stencil-extent sten Y))
+              (xtrans (car xex))
+              (ytrans (car yex))
+              (uplist
+                (map pair-to-list
+                     (normalize-coords coords lenx 3)))
+              (downlist
+                (map pair-to-list
+                     (normalize-coords coords lenx -3))))
+
+  (ly:stencil-translate
+      (my-c-p-s uplist thick)
+    (cons xtrans ytrans)))
+  '())))
+
+#(define semi-tone-gliss
+  (elbowed-glissando '((0.5 . -0.5) (1.0 . 0.15))))
+
+#(define tone-gliss
+  (elbowed-glissando '((0 . -0.5) (1.0 . -0.35) (1.0 . 0.16))))
+
+#(define three-semi-tone-gliss
+  (elbowed-glissando '((0 . -0.35) (0.5 . -0.7) (1.0 . -0.2) (1.0 . 0.15))))
+
+scaleSettings = {
+  \override Glissando #'Y-offset = #-1
+  \override Glissando #'thickness = #0.2
+  \override Glissando #'bound-details =
+     #'((left    (padding . 0.2))
+        (right   (end-on-accidental . #f) (padding . 0.2)))
+}
+
+revertScaleSettings = {
+  \revert Glissando #'Y-offset
+  \revert Glissando #'thickness
+  \revert Glissando #'bound-details
+}
+
+
+semiTone =
+#(define-event-function (parser location)()
+#{
+        \tweak #'stencil #semi-tone-gliss
+        \glissando
+#})
+
+tone =
+#(define-event-function (parser location)()
+#{
+        \tweak #'stencil #tone-gliss
+        \glissando
+#})
+
+threeSemiTone =
+#(define-event-function (parser location)()
+#{
+        \tweak #'stencil #three-semi-tone-gliss
+        \glissando
+#})

--- a/notation-snippets/interval-brackets/definitions.ily
+++ b/notation-snippets/interval-brackets/definitions.ily
@@ -27,60 +27,60 @@
 
 #(define ((elbowed-glissando coords) grob)
 
- (define (pair-to-list pair)
-    (list (car pair) (cdr pair)))
+   (define (pair-to-list pair)
+     (list (car pair) (cdr pair)))
 
- (define (normalize-coords goods x y)
-   (map
-     (lambda (coord)
-       (cons (* x (car coord)) (* y (cdr coord))))
-     goods))
+   (define (normalize-coords goods x y)
+     (map
+      (lambda (coord)
+        (cons (* x (car coord)) (* y (cdr coord))))
+      goods))
 
- (define (my-c-p-s points thick)
-   (make-connected-path-stencil
-     points
-     thick
-     1.0
-     1.0
-     #f
-     #f))
+   (define (my-c-p-s points thick)
+     (make-connected-path-stencil
+      points
+      thick
+      1.0
+      1.0
+      #f
+      #f))
 
-; outer let to trigger suicide
- (let ((sten (ly:line-spanner::print grob)))
-   (if (grob::is-live? grob)
-       (let* ((thick (ly:grob-property grob 'thickness 0.1))
-              (xex (ly:stencil-extent sten X))
-              (lenx (interval-length xex))
-              (yex (ly:stencil-extent sten Y))
-              (xtrans (car xex))
-              (ytrans (car yex))
-              (uplist
-                (map pair-to-list
-                     (normalize-coords coords lenx 3)))
-              (downlist
-                (map pair-to-list
-                     (normalize-coords coords lenx -3))))
+   ; outer let to trigger suicide
+   (let ((sten (ly:line-spanner::print grob)))
+     (if (grob::is-live? grob)
+         (let* ((thick (ly:grob-property grob 'thickness 0.1))
+                (xex (ly:stencil-extent sten X))
+                (lenx (interval-length xex))
+                (yex (ly:stencil-extent sten Y))
+                (xtrans (car xex))
+                (ytrans (car yex))
+                (uplist
+                 (map pair-to-list
+                   (normalize-coords coords lenx 3)))
+                (downlist
+                 (map pair-to-list
+                   (normalize-coords coords lenx -3))))
 
-  (ly:stencil-translate
-      (my-c-p-s uplist thick)
-    (cons xtrans ytrans)))
-  '())))
+           (ly:stencil-translate
+            (my-c-p-s uplist thick)
+            (cons xtrans ytrans)))
+         '())))
 
 #(define semi-tone-gliss
-  (elbowed-glissando '((0.5 . -0.5) (1.0 . 0.15))))
+   (elbowed-glissando '((0.5 . -0.5) (1.0 . 0.15))))
 
 #(define tone-gliss
-  (elbowed-glissando '((0 . -0.5) (1.0 . -0.35) (1.0 . 0.16))))
+   (elbowed-glissando '((0 . -0.5) (1.0 . -0.35) (1.0 . 0.16))))
 
 #(define three-semi-tone-gliss
-  (elbowed-glissando '((0 . -0.35) (0.5 . -0.7) (1.0 . -0.2) (1.0 . 0.15))))
+   (elbowed-glissando '((0 . -0.35) (0.5 . -0.7) (1.0 . -0.2) (1.0 . 0.15))))
 
 intervalBracketsOn = {
   \override Glissando #'Y-offset = #-1
   \override Glissando #'thickness = #0.2
   \override Glissando #'bound-details =
-     #'((left    (padding . 0.2))
-        (right   (end-on-accidental . #f) (padding . 0.2)))
+  #'((left    (padding . 0.2))
+     (right   (end-on-accidental . #f) (padding . 0.2)))
 }
 
 intervalBracketsOff = {
@@ -92,21 +92,21 @@ intervalBracketsOff = {
 
 semiTone =
 #(define-event-function (parser location)()
-#{
-        \tweak #'stencil #semi-tone-gliss
-        \glissando
-#})
+   #{
+     \tweak #'stencil #semi-tone-gliss
+     \glissando
+   #})
 
 tone =
 #(define-event-function (parser location)()
-#{
-        \tweak #'stencil #tone-gliss
-        \glissando
-#})
+   #{
+     \tweak #'stencil #tone-gliss
+     \glissando
+   #})
 
 threeSemiTone =
 #(define-event-function (parser location)()
-#{
-        \tweak #'stencil #three-semi-tone-gliss
-        \glissando
-#})
+   #{
+     \tweak #'stencil #three-semi-tone-gliss
+     \glissando
+   #})

--- a/notation-snippets/interval-brackets/example.ly
+++ b/notation-snippets/interval-brackets/example.ly
@@ -1,0 +1,19 @@
+\version "2.16.2"
+\include "definitions.ily"
+
+\markup \bold \huge "Interval Brackets"
+
+\relative c' {
+  \override Staff.TimeSignature #'stencil = ##f
+  \time 32/4
+  \scaleSettings
+  c1\tone
+  d\semiTone
+  ees\tone
+  f\tone
+  g\semiTone
+  as\threeSemiTone
+  b!\semiTone c
+  \bar "|."
+  \revertScaleSettings
+}

--- a/notation-snippets/interval-brackets/example.ly
+++ b/notation-snippets/interval-brackets/example.ly
@@ -6,7 +6,7 @@
 \relative c' {
   \override Staff.TimeSignature #'stencil = ##f
   \time 32/4
-  \scaleSettings
+  \intervalBracketsOn
   c1\tone
   d\semiTone
   ees\tone
@@ -15,5 +15,5 @@
   as\threeSemiTone
   b!\semiTone c
   \bar "|."
-  \revertScaleSettings
+  \intervalBracketsOff
 }


### PR DESCRIPTION
I propose two new snippets: 1. tone and semi-tone brackets for muscial education notation and 2. a shorthand for setting four components of the vertical spacing
