### PR TITLE
smufl ligatures

### DIFF
--- a/custom-music-fonts/smufl/README.md
+++ b/custom-music-fonts/smufl/README.md
@@ -52,6 +52,15 @@ To revert things back to normal, use `\bravuraOff` or `\smuflOff`.
 
 To invoke a glyph by name like `\musicglyph`, use the markup command `\smuflglyph`. `\smuflglyph #"segno"`, for example, will print a segno sign in the Bravura font. `\smuflglyph` is **not** compatible wih `\musicglyph`, and manual conversion may be necessary. Sorry!
 
+`\smuflchar` is the same as `\smuflglyph`, but it takes a Unicode code point in place of a glyph name.
+
+`\smufllig` takes a list of glyph names (in the form of strings, not symbols) and concatenates them together. This is useful because it can create ligatures; there is no way to do so using the other two commands:
+
+    % Wrong:
+    \concat { \smuflglyph #"gClefLigatedNumberAbove" \smuflglyph #"tuplet5" }
+    % Right:
+    \smufllig #("gClefLigatedNumberAbove" "tuplet5")
+
 A few other new commands are added, such as the dynamics `\pppppp`, `\ffffff`, and `\niente`.
 
 If you want access to LilySMuFL's new commands, but don't want to slow down compilation for now, leave the include in place and comment out `\bravuraOn` or `\smuflOn`. Now you can use `\smuflglyph`, etc. while keeping compilation speedy. There is a caveat: if you use `\niente`, add this line where you would put `\bravuraOn`:

--- a/custom-music-fonts/smufl/definitions.ily
+++ b/custom-music-fonts/smufl/definitions.ily
@@ -186,6 +186,14 @@
    (interpret-markup layout props
      (markup (#:fontsize 5 #:override `(font-name . ,smufl-font) #:char charnum))))
 
+#(define-markup-command (smufllig layout props glyphs) (list?)
+   (interpret-markup layout props
+     (markup (#:fontsize 5 #:override `(font-name . ,smufl-font)
+               (apply string-append
+                 (map
+                   (lambda (glyphname) (ly:wide-char->utf-8 (cdr (assoc glyphname smufl-map))))
+                   glyphs))))))
+
 % TODO: Support for ottavation
 #(define (smufl-clef grob)
    (let* ((glyphname (ly:grob-property grob 'glyph-name))

--- a/custom-music-fonts/smufl/example.ly
+++ b/custom-music-fonts/smufl/example.ly
@@ -17,3 +17,5 @@ music = \relative c' {
   \new Staff \with { instrumentName = "Feta" } \music
   \new Staff \with { \bravuraOn instrumentName = "Bravura" } \music
 >>
+
+\markup { \smufllig #'("gClefLigatedNumberAbove" "tuplet4") }


### PR DESCRIPTION
Adds a markup command `\smufllig` that permits the creation of ligature.
