### PR TITLE
move index higher in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,48 @@ nature of GitHub.
 -->
 
 
+Contents
+========
+
+* [__custom-music-fonts__](custom-music-fonts) -
+    alternative fonts for LilyPond, that can be used instead of default Feta.
+* [__debugging-layout__](debugging-layout) -
+    tools that visualize LilyPond's layout decisions (e.g. directions),
+* [__general-tools__](general-tools) -
+    stuff for working on and with LilyPond itself.
+* [__input-shorthands__](input-shorthands) -
+    music functions and other tools that make writing LilyPond code easier,
+* [__notation-snippets__](notation-snippets) -
+    LilyPond code that produces some particular notation,
+* [__simple-examples__](simple-examples) -
+    snippets that are just explaining or demonstrating things from the documentation,
+* [__specific-solutions__](specific-solutions) -
+    hacks that aren't generic, just solve a very specific problem,
+* [__stylesheets__](stylesheets) -
+    a place for collections of user-designed layout settings ("house styles"),
+* [__templates__](templates) -
+    examples showing how to structure LilyPond code.
+
+Every category has a `README.md` file inside with more details,
+but if you're not sure which category to choose, don't worry!
+*It's not that important.*
+
+<!---
+Later on, we may divide the snippets into 2 (or more)
+"quality levels":
+- official ones, showing Recommended LilyPond Practice,
+- drafts, hacks etc. that were just written by someone
+  and may be useful, but may also not be.
+
+The policy would be to allow anyone to add anything to the "hacks",
+but adding/changing official ones (or moving a draft to official ones)
+would require some confirmation from someone else (not necessarily
+a full review, but at least a quick look).
+
+Update: actually, the status field probably already does this.
+-->
+
+
 Using this repository
 =====================
 
@@ -93,48 +135,6 @@ _Format_ tool.
 * When you make changes in your snippets, please contribute
 updates to the repository! :-)
 
-
-Snippet categories
-==================
-
-* [__custom-music-fonts__](custom-music-fonts) -
-    alternative fonts for LilyPond, that can be used instead of default Feta.
-* [__debugging-layout__](debugging-layout) -
-    tools that visualize LilyPond's layout decisions (e.g. directions),
-* [__general-tools__](general-tools) -
-    stuff for working on and with LilyPond itself.
-* [__input-shorthands__](input-shorthands) -
-    music functions and other tools that make writing LilyPond code easier,
-* [__notation-snippets__](notation-snippets) -
-    LilyPond code that produces some particular notation,
-* [__simple-examples__](simple-examples) -
-    snippets that are just explaining or demonstrating things from the documentation,
-* [__specific-solutions__](specific-solutions) -
-    hacks that aren't generic, just solve a very specific problem,
-* [__stylesheets__](stylesheets) -
-    a place for collections of user-designed layout settings ("house styles"),
-* [__templates__](templates) -
-    examples showing how to structure LilyPond code.
-
-Every category has a `README.md` file inside with more details,
-but if you're not sure which category to choose, don't worry!
-*It's not that important.*
-
-
-<!---
-Later on, we may divide the snippets into 2 (or more)
-"quality levels":
-- official ones, showing Recommended LilyPond Practice,
-- drafts, hacks etc. that were just written by someone
-  and may be useful, but may also not be.
-
-The policy would be to allow anyone to add anything to the "hacks",
-but adding/changing official ones (or moving a draft to official ones)
-would require some confirmation from someone else (not necessarily
-a full review, but at least a quick look).
-
-Update: actually, the status field probably already does this.
--->
 
 Contact
 =======


### PR DESCRIPTION
For people who have just discovered this repository, learning how to use it or contribute to it is irrelevant until they first establish that they are somehow interested in the contents.  So move the index to appear before the "Using this repository" or "Contributing" sections.

Additionally, rename the index from "Snippet categories" to "Contents", since not all items are snippets.
