### PR TITLE
Add "Scale vertical spacing"

### DIFF
--- a/notation-snippets/scale-vertical-spacing/README.md
+++ b/notation-snippets/scale-vertical-spacing/README.md
@@ -1,5 +1,4 @@
-Scale Vertical Spacing
----------------------
+## Scale Vertical Spacing
 
 This snippet provides an easier way to adjust vertical spacing by letting you scale the default vertical spacing settings.  It provides two functions:
 
@@ -11,73 +10,73 @@ These functions should be placed at the top level of a file, where layout blocks
 
 They take a single argument.  The argument can simply be a number, which is then used to scale _all_ applicable vertical spacing properties by that amount. 
 
-	\scaleVerticalSpacingPageLayout #1.5
-	\scaleVerticalSpacingInSystems #1.4
+    \scaleVerticalSpacingPageLayout #1.5
+    \scaleVerticalSpacingInSystems #1.4
 
 This may be sufficient in some cases, but for more control and flexibility the argument can be an "association list" that specifies different scaling values for different items.
 
-	% scale specific page layout variables by specific amounts
-	
-	\scaleVerticalSpacingPageLayout
-	#'((all . 1.1)
-	   (system-system . 1.2)
-	   (score-system . 1.3)
-	   (markup-system . 1.4)
-	   (score-markup . 1.5)
-	   (markup-markup . 1.6)
-	   (top-system . 1.7)
-	   (top-markup . 1.8)
-	   (last-bottom . 1.9))
+    % scale specific page layout variables by specific amounts
+    
+    \scaleVerticalSpacingPageLayout
+    #'((all . 1.1)
+       (system-system . 1.2)
+       (score-system . 1.3)
+       (markup-system . 1.2)
+       (score-markup . 1.3)
+       (markup-markup . 1.2)
+       (top-system . 1.3)
+       (top-markup . 1.2)
+       (last-bottom . 1.3))
 
-	% scale the properties of specific contexts (and/or properties of the StaffGrouper grob, which is not a context)
-	
-	\scaleVerticalSpacingInSystems
-	#'((all . 1.1)
-	   (staff-grouper . 1.2)
-	   (staff . 1.3)
-	   (chord-names . 1.4)
-	   (dynamics . 1.5)
-	   (figured-bass . 1.6)
-	   (lyrics . 1.7)
-	   (note-names . 1.8))
+    % scale the properties of specific contexts (and/or properties of the StaffGrouper grob, which is not a context)
+    
+    \scaleVerticalSpacingInSystems
+    #'((all . 1.1)
+       (staff-grouper . 1.2)
+       (staff . 1.3)
+       (chord-names . 1.2)
+       (dynamics . 1.3)
+       (figured-bass . 1.2)
+       (lyrics . 1.3)
+       (note-names . 1.2))
 
 The value for `all` sets the scaling factor for all of the different items (just like providing a single number as an argument).  The value for all is replaced by any more specific settings.  For example:
 
-	\scaleVerticalSpacingInSystems
-	#'((all . 1.4)
-	   (staff-grouper . 1)
-	   (lyrics . 1.2))
+    \scaleVerticalSpacingInSystems
+    #'((all . 1.4)
+       (staff-grouper . 1)
+       (lyrics . 1.2))
 
 This keeps the default staff-grouper spacing, but scales everything else by 1.4, except for lyrics, which is scaled by 1.2.
 
 With `scaleVerticalSpacingInSystems` you can get even more detailed and specify different scaling factors for specific context properties:
 
-	% scale specific properties within specific contexts (and/or of the StaffGrouper grob, which is not a context)
-	
-	\scaleVerticalSpacingInSystems
-	#'((all . 1)
-	   (staff-grouper-staff-staff . 1)
-	   (staff-grouper-staffgroup-staff . 1)
-	   (staff-default-staff-staff . 1) ;; same as (staff . 1)
-	   (chord-names-nonstaff-relatedstaff . 1)
-	   (chord-names-nonstaff-nonstaff . 1)
-	   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
-	   (figured-bass-nonstaff-relatedstaff . 1)
-	   (figured-bass-nonstaff-nonstaff . 1)
-	   (lyrics-nonstaff-relatedstaff . 1)
-	   (lyrics-nonstaff-nonstaff . 1)
-	   (lyrics-nonstaff-unrelatedstaff . 1)
-	   (note-names-nonstaff-relatedstaff . 1)
-	   (note-names-nonstaff-nonstaff . 1)
-	   (note-names-nonstaff-unrelatedstaff . 1))
+    % scale specific properties within specific contexts (and/or of the StaffGrouper grob, which is not a context)
+    
+    \scaleVerticalSpacingInSystems
+    #'((all . 1.1)
+       (staff-grouper-staff-staff . 1.2)
+       (staff-grouper-staffgroup-staff . 1.3)
+       (staff-default-staff-staff . 1.2) ;; same as (staff . 1.2)
+       (chord-names-nonstaff-relatedstaff . 1.3)
+       (chord-names-nonstaff-nonstaff . 1.2)
+       (dynamics-nonstaff-relatedstaff . 1.3) ;; same as (dynamics . 1.3)
+       (figured-bass-nonstaff-relatedstaff . 1.2)
+       (figured-bass-nonstaff-nonstaff . 1.3)
+       (lyrics-nonstaff-relatedstaff . 1.2)
+       (lyrics-nonstaff-nonstaff . 1.3)
+       (lyrics-nonstaff-unrelatedstaff . 1.2)
+       (note-names-nonstaff-relatedstaff . 1.3)
+       (note-names-nonstaff-nonstaff . 1.2)
+       (note-names-nonstaff-unrelatedstaff . 1.3))
 
 
 Again, more specific settings trump more general settings.  The following will scale everything by 1.5, except for lyrics context properties which will be scaled by 1.3, except for the `Lyrics.nonstaff-nonstaff-spacing` property, which will not be scaled at all.
 
-	\scaleVerticalSpacingInSystems
-	#'((all . 1.5)
-	   (lyrics . 1.3)
-	   (lyrics-nonstaff-nonstaff . 1))
+    \scaleVerticalSpacingInSystems
+    #'((all . 1.5)
+       (lyrics . 1.3)
+       (lyrics-nonstaff-nonstaff . 1))
 
 ### Background
 
@@ -109,159 +108,155 @@ In other words, they are not meant to provide a "smart" high-level algorithm tha
 
 ### Appendix: Default Settings
 
-You don't need to know these, but here they are.
-
-**Page Layout Variables**
+You don't need to know these, but here they are for reference.
 
 <table>
-	<tr>
-		<th>property</th>
-		<th>basic-distance</th>
-		<th>minimum-distance</th>
-		<th>padding</th>
-	</tr>
-	<tr>
-		<td>system-system-spacing</td>
-		<td>12</td>
-		<td>8</td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td>score-system-spacing</td>
-		<td>14</td>
-		<td>8</td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td>markup-system-spacing</td>
-		<td>5</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>score-markup-spacing</td>
-		<td>12</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>markup-markup-spacing</td>
-		<td>1</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>top-system-spacing</td>
-		<td>1</td>
-		<td>0</td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td>top-markup-spacing</td>
-		<td>0</td>
-		<td>0</td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td>last-bottom-spacing</td>
-		<td>1</td>
-		<td>0</td>
-		<td>1</td>
-	</tr>
+    <tr>
+        <th>Page Layout Variables</th>
+        <th>basic-distance</th>
+        <th>minimum-distance</th>
+        <th>padding</th>
+    </tr>
+    <tr>
+        <td>system-system-spacing</td>
+        <td>12</td>
+        <td>8</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>score-system-spacing</td>
+        <td>14</td>
+        <td>8</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>markup-system-spacing</td>
+        <td>5</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>score-markup-spacing</td>
+        <td>12</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>markup-markup-spacing</td>
+        <td>1</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>top-system-spacing</td>
+        <td>1</td>
+        <td>0</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>top-markup-spacing</td>
+        <td>0</td>
+        <td>0</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>last-bottom-spacing</td>
+        <td>1</td>
+        <td>0</td>
+        <td>1</td>
+    </tr>
 </table>
-
-**In-System Context and Grob Properties**
 
 <table>
-	<tr>
-		<th>property</th>
-		<th>basic-distance</th>
-		<th>minimum-distance</th>
-		<th>padding</th>
-	</tr>
-	<tr>
-		<td>StaffGrouper.staff-staff-spacing</td>
-		<td>9</td>
-		<td>7</td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td>StaffGrouper.staffgroup-staff-spacing</td>
-		<td>10.5</td>
-		<td>8</td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td>Staff -- VerticalAxisGroup.default-staff-staff-spacing</td>
-		<td>9</td>
-		<td>8</td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td>ChordNames -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
-		<td>0</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>ChordNames -- VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
-		<td>0</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>Dynamics -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
-		<td>5</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>FiguredBass -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
-		<td>0</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>FiguredBass -- VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
-		<td>0</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>Lyrics -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
-		<td>5.5</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>Lyrics -- VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
-		<td>0</td>
-		<td>2.8</td>
-		<td>0.2</td>
-	</tr>
-	<tr>
-		<td>Lyrics -- VerticalAxisGroup.nonstaff-unrelatedstaff-spacing</td>
-		<td>0</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>NoteNames -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
-		<td>5.5</td>
-		<td>0</td>
-		<td>0.5</td>
-	</tr>
-	<tr>
-		<td>NoteNames -- VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
-		<td>0</td>
-		<td>2.8</td>
-		<td>0.2</td>
-	</tr>
-	<tr>
-		<td>NoteNames -- VerticalAxisGroup.nonstaff-unrelatedstaff-spacing</td>
-		<td>0</td>
-		<td>0</td>
-		<td>1.5</td>
-	</tr>
+    <tr>
+        <th>In-System Context and Grob Properties</th>
+        <th>basic-distance</th>
+        <th>minimum-distance</th>
+        <th>padding</th>
+    </tr>
+    <tr>
+        <td>StaffGrouper.staff-staff-spacing</td>
+        <td>9</td>
+        <td>7</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>StaffGrouper.staffgroup-staff-spacing</td>
+        <td>10.5</td>
+        <td>8</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>Staff -> VerticalAxisGroup.default-staff-staff-spacing</td>
+        <td>9</td>
+        <td>8</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>ChordNames -> VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>ChordNames -> VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>Dynamics -> VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+        <td>5</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>FiguredBass -> VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>FiguredBass -> VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>Lyrics -> VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+        <td>5.5</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>Lyrics -> VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
+        <td>0</td>
+        <td>2.8</td>
+        <td>0.2</td>
+    </tr>
+    <tr>
+        <td>Lyrics -> VerticalAxisGroup.nonstaff-unrelatedstaff-spacing</td>
+        <td>0</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>NoteNames -> VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+        <td>5.5</td>
+        <td>0</td>
+        <td>0.5</td>
+    </tr>
+    <tr>
+        <td>NoteNames -> VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
+        <td>0</td>
+        <td>2.8</td>
+        <td>0.2</td>
+    </tr>
+    <tr>
+        <td>NoteNames -> VerticalAxisGroup.nonstaff-unrelatedstaff-spacing</td>
+        <td>0</td>
+        <td>0</td>
+        <td>1.5</td>
+    </tr>
 </table>
-			
+            

--- a/notation-snippets/scale-vertical-spacing/README.md
+++ b/notation-snippets/scale-vertical-spacing/README.md
@@ -1,0 +1,1 @@
+This README file is a work in progress... see example.ly for now.

--- a/notation-snippets/scale-vertical-spacing/README.md
+++ b/notation-snippets/scale-vertical-spacing/README.md
@@ -1,1 +1,267 @@
-This README file is a work in progress... see example.ly for now.
+Scale Vertical Spacing
+---------------------
+
+This snippet provides an easier way to adjust vertical spacing by letting you scale the default vertical spacing settings.  It provides two functions:
+
+* `scaleVerticalSpacingPageLayout` -- for scaling page layout variables that affect vertical spacing outside of systems (see [docs](http://lilypond.org/doc/v2.18/Documentation/notation/flexible-vertical-spacing-paper-variables)). Returns a paper block that sets new values for these variables.
+
+* `scaleVerticalSpacingInSystems` -- for scaling context properties and grob properties that affect vertical spacing within musical systems (see [docs](http://lilypond.org/doc/v2.18/Documentation/notation/flexible-vertical-spacing-within-systems)). Returns a layout block that sets new values for these properties. 
+
+These functions should be placed at the top level of a file, where layout blocks and paper blocks go (because they return a paper block and a layout block).  
+
+They take a single argument.  The argument can simply be a number, which is then used to scale _all_ applicable vertical spacing properties by that amount. 
+
+	\scaleVerticalSpacingPageLayout #1.5
+	\scaleVerticalSpacingInSystems #1.4
+
+This may be sufficient in some cases, but for more control and flexibility the argument can be an "association list" that specifies different scaling values for different items.
+
+	% scale specific page layout variables by specific amounts
+	
+	\scaleVerticalSpacingPageLayout
+	#'((all . 1.1)
+	   (system-system . 1.2)
+	   (score-system . 1.3)
+	   (markup-system . 1.4)
+	   (score-markup . 1.5)
+	   (markup-markup . 1.6)
+	   (top-system . 1.7)
+	   (top-markup . 1.8)
+	   (last-bottom . 1.9))
+
+	% scale the properties of specific contexts (and/or properties of the StaffGrouper grob, which is not a context)
+	
+	\scaleVerticalSpacingInSystems
+	#'((all . 1.1)
+	   (staff-grouper . 1.2)
+	   (staff . 1.3)
+	   (chord-names . 1.4)
+	   (dynamics . 1.5)
+	   (figured-bass . 1.6)
+	   (lyrics . 1.7)
+	   (note-names . 1.8))
+
+The value for `all` sets the scaling factor for all of the different items (just like providing a single number as an argument).  The value for all is replaced by any more specific settings.  For example:
+
+	\scaleVerticalSpacingInSystems
+	#'((all . 1.4)
+	   (staff-grouper . 1)
+	   (lyrics . 1.2))
+
+This keeps the default staff-grouper spacing, but scales everything else by 1.4, except for lyrics, which is scaled by 1.2.
+
+With `scaleVerticalSpacingInSystems` you can get even more detailed and specify different scaling factors for specific context properties:
+
+	% scale specific properties within specific contexts (and/or of the StaffGrouper grob, which is not a context)
+	
+	\scaleVerticalSpacingInSystems
+	#'((all . 1)
+	   (staff-grouper-staff-staff . 1)
+	   (staff-grouper-staffgroup-staff . 1)
+	   (staff-default-staff-staff . 1) ;; same as (staff . 1)
+	   (chord-names-nonstaff-relatedstaff . 1)
+	   (chord-names-nonstaff-nonstaff . 1)
+	   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
+	   (figured-bass-nonstaff-relatedstaff . 1)
+	   (figured-bass-nonstaff-nonstaff . 1)
+	   (lyrics-nonstaff-relatedstaff . 1)
+	   (lyrics-nonstaff-nonstaff . 1)
+	   (lyrics-nonstaff-unrelatedstaff . 1)
+	   (note-names-nonstaff-relatedstaff . 1)
+	   (note-names-nonstaff-nonstaff . 1)
+	   (note-names-nonstaff-unrelatedstaff . 1))
+
+
+Again, more specific settings trump more general settings.  The following will scale everything by 1.5, except for lyrics context properties which will be scaled by 1.3, except for the `Lyrics.nonstaff-nonstaff-spacing` property, which will not be scaled at all.
+
+	\scaleVerticalSpacingInSystems
+	#'((all . 1.5)
+	   (lyrics . 1.3)
+	   (lyrics-nonstaff-nonstaff . 1))
+
+### Background
+
+The process for adjusting vertical spacing in LilyPond can be challenging.  
+
+1. You have to identify which properties need to be adjusted. (e.g. do I override `StaffGrouper.staff-staff-spacing` or `StaffGrouper.staffgroup-staff-spacing`?)
+2. Each property has three properties of its own, so you have to decide which one of those to change (e.g. do I change `basic-distance`, `minimum-distance`, or `padding`?)
+3. If you want to know the default values for these settings, in order to be aware of how much you are changing them, you have to look each one up in the internals reference.
+
+This snippet simplifies this process for you.  It is much simpler to scale the default values, rather than either looking them up in different places, or making a wild guess at what a good value might be. 
+
+You also don't have to decide whether to adjust `basic-distance`, `minimum-distance`, or `padding`, since these functions scale all three of them together, maintaining the proportions between them. This way you are more likely to arrive at a good result than picking one and changing it in isolation (unless you _really_ know what you are doing).
+
+Finally, it lets you be as detailed and specific as you want: 
+
+* You can adjust all vertical spacing settings with a single scaling factor when that is sufficient.
+* You can provide different scaling factors for different items to adjust all the relevant properties for those items. 
+* For items with more than one property that affects vertical spacing, you can specify different scaling factors for each of those properties.
+
+### Suggested Use
+
+Work from general to specific.  Start by adjusting vertical spacing in general, then get more specific if certain items need more or less spacing.
+
+### Disclaimer
+
+These functions do not guarantee good spacing for all values you could feed them, nor do they try to do that. They aim to improve upon the usual process for adjusting vertical spacing. They make it easier to do, and should make it more likely that you will arrive at good results.
+
+In other words, they are not meant to provide a "smart" high-level algorithm that always gets the spacing right by deciding for you how much to scale one thing vs another. They are meant as lower-level, dumb/consistent/simple/transparent tools that make it easier for you to adjust vertical spacing as you see fit.
+
+### Appendix: Default Settings
+
+You don't need to know these, but here they are.
+
+**Page Layout Variables**
+
+<table>
+	<tr>
+		<th>property</th>
+		<th>basic-distance</th>
+		<th>minimum-distance</th>
+		<th>padding</th>
+	</tr>
+	<tr>
+		<td>system-system-spacing</td>
+		<td>12</td>
+		<td>8</td>
+		<td>1</td>
+	</tr>
+	<tr>
+		<td>score-system-spacing</td>
+		<td>14</td>
+		<td>8</td>
+		<td>1</td>
+	</tr>
+	<tr>
+		<td>markup-system-spacing</td>
+		<td>5</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>score-markup-spacing</td>
+		<td>12</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>markup-markup-spacing</td>
+		<td>1</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>top-system-spacing</td>
+		<td>1</td>
+		<td>0</td>
+		<td>1</td>
+	</tr>
+	<tr>
+		<td>top-markup-spacing</td>
+		<td>0</td>
+		<td>0</td>
+		<td>1</td>
+	</tr>
+	<tr>
+		<td>last-bottom-spacing</td>
+		<td>1</td>
+		<td>0</td>
+		<td>1</td>
+	</tr>
+</table>
+
+**In-System Context and Grob Properties**
+
+<table>
+	<tr>
+		<th>property</th>
+		<th>basic-distance</th>
+		<th>minimum-distance</th>
+		<th>padding</th>
+	</tr>
+	<tr>
+		<td>StaffGrouper.staff-staff-spacing</td>
+		<td>9</td>
+		<td>7</td>
+		<td>1</td>
+	</tr>
+	<tr>
+		<td>StaffGrouper.staffgroup-staff-spacing</td>
+		<td>10.5</td>
+		<td>8</td>
+		<td>1</td>
+	</tr>
+	<tr>
+		<td>Staff -- VerticalAxisGroup.default-staff-staff-spacing</td>
+		<td>9</td>
+		<td>8</td>
+		<td>1</td>
+	</tr>
+	<tr>
+		<td>ChordNames -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+		<td>0</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>ChordNames -- VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
+		<td>0</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>Dynamics -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+		<td>5</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>FiguredBass -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+		<td>0</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>FiguredBass -- VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
+		<td>0</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>Lyrics -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+		<td>5.5</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>Lyrics -- VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
+		<td>0</td>
+		<td>2.8</td>
+		<td>0.2</td>
+	</tr>
+	<tr>
+		<td>Lyrics -- VerticalAxisGroup.nonstaff-unrelatedstaff-spacing</td>
+		<td>0</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>NoteNames -- VerticalAxisGroup.nonstaff-relatedstaff-spacing</td>
+		<td>5.5</td>
+		<td>0</td>
+		<td>0.5</td>
+	</tr>
+	<tr>
+		<td>NoteNames -- VerticalAxisGroup.nonstaff-nonstaff-spacing</td>
+		<td>0</td>
+		<td>2.8</td>
+		<td>0.2</td>
+	</tr>
+	<tr>
+		<td>NoteNames -- VerticalAxisGroup.nonstaff-unrelatedstaff-spacing</td>
+		<td>0</td>
+		<td>0</td>
+		<td>1.5</td>
+	</tr>
+</table>
+			

--- a/notation-snippets/scale-vertical-spacing/definitions.ily
+++ b/notation-snippets/scale-vertical-spacing/definitions.ily
@@ -214,9 +214,11 @@ scaleVerticalSpacingInSystems =
 %{
 
 % A1. scale all page layout variables by the same amount
+
 \scaleVerticalSpacingPageLayout #1.5
 
 % A2. scale specific page layout variables
+
 \scaleVerticalSpacingPageLayout
 #'((all . 1)
    (system-system . 1)
@@ -229,10 +231,12 @@ scaleVerticalSpacingInSystems =
    (last-bottom . 1))
 
 % B1. scale all properties by the same amount
+
 \scaleVerticalSpacingInSystems #1.5
 
 % B2. scale properties for specific contexts
-% (or of the StaffGrouper grob, which is not a context)
+% (or of the StaffGrouper grob -- not a context)
+
 \scaleVerticalSpacingInSystems
 #'((all . 1)
    (staff-grouper . 1)
@@ -244,7 +248,8 @@ scaleVerticalSpacingInSystems =
    (note-names . 1))
 
 % B3. scale specific properties within specific contexts
-% (or of the StaffGrouper grob, which is not a context)
+% (or of the StaffGrouper grob -- not a context)
+
 \scaleVerticalSpacingInSystems
 #'((all . 1)
    (staff-grouper-staff-staff . 1)
@@ -261,30 +266,4 @@ scaleVerticalSpacingInSystems =
    (note-names-nonstaff-relatedstaff . 1)
    (note-names-nonstaff-nonstaff . 1)
    (note-names-nonstaff-unrelatedstaff . 1))
-
-% B2 & B3
-\scaleVerticalSpacingInSystems
-#'((all . 1)
-   (staff-grouper . 1)
-   (staff . 1)
-   (chord-names . 1)
-   (dynamics . 1)
-   (figured-bass . 1)
-   (lyrics . 1)
-   (note-names . 1)
-   (staff-grouper-staff-staff . 1)
-   (staff-grouper-staffgroup-staff . 1)
-   (staff-default-staff-staff . 1) ;; same as (staff . 1)
-   (chord-names-nonstaff-relatedstaff . 1)
-   (chord-names-nonstaff-nonstaff . 1)
-   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
-   (figured-bass-nonstaff-relatedstaff . 1)
-   (figured-bass-nonstaff-nonstaff . 1)
-   (lyrics-nonstaff-relatedstaff . 1)
-   (lyrics-nonstaff-nonstaff . 1)
-   (lyrics-nonstaff-unrelatedstaff . 1)
-   (note-names-nonstaff-relatedstaff . 1)
-   (note-names-nonstaff-nonstaff . 1)
-   (note-names-nonstaff-unrelatedstaff . 1))
-
 %}

--- a/notation-snippets/scale-vertical-spacing/definitions.ily
+++ b/notation-snippets/scale-vertical-spacing/definitions.ily
@@ -22,7 +22,8 @@ scaleVerticalSpacingPageLayout =
 #(define-scheme-function (parser location arg) (number-or-list?)
    "Multiplies the default values of the flexible vertical spacing paper 
     variables by the amounts specified in @{arg}, a number or alist. 
-    Returns a paper block."
+    Returns a paper block. See:
+    http://lilypond.org/doc/v2.18/Documentation/notation/flexible-vertical-spacing-paper-variables"
    (let*
     ;; Get scaling factors from arg.
     ((all (or (assq-ref arg 'all) (if (number? arg) arg)))
@@ -73,7 +74,8 @@ scaleVerticalSpacingInSystems =
 #(define-scheme-function (parser location arg) (number-or-list?)
    "Multiplies the default values of the grob-properties that affect 
     flexible vertical spacing within systems by the amounts specified 
-    in @{arg}, a number or alist.  Returns a layout block."
+    in @{arg}, a number or alist.  Returns a layout block. See:
+    http://lilypond.org/doc/v2.18/Documentation/notation/flexible-vertical-spacing-within-systems"
    ;; FretBoards do not set any grob-properties in VerticalAxisGroup,
    ;; so there's nothing to scale for them, so they are not included.
    (let*

--- a/notation-snippets/scale-vertical-spacing/definitions.ily
+++ b/notation-snippets/scale-vertical-spacing/definitions.ily
@@ -1,0 +1,288 @@
+\version "2.19.13"
+
+\header {
+  snippet-title = "Scale vertical spacing"
+  snippet-author = "Paul Morris"
+  snippet-source = ""
+  snippet-description = \markup {
+    Provides two functions for scaling vertical spacing.  One scales the
+    spacing of elements within systems (staff, staff groups, lyrics, chord
+    names, etc.) and the other scales the spacing of page layout
+    elements outside of systems (systems, top-level markups, etc.).
+  }
+  tags = "spacing, vertical-spacing, page-layout"
+  status = "ready"
+}
+
+% Custom type predicate:
+#(define (number-or-list? x)
+   (or (number? x) (list? x)))
+
+scaleVerticalSpacingPageLayout =
+#(define-scheme-function (parser location arg) (number-or-list?)
+   "Multiplies the default values of the flexible vertical spacing paper 
+    variables by the amounts specified in @{arg}, a number or alist. 
+    Returns a paper block."
+   (let*
+    ;; Get scaling factors from arg.
+    ((all (or (assq-ref arg 'all) (if (number? arg) arg)))
+     (sys-sys (or (assq-ref arg 'system-system) all 1))
+     (score-sys (or (assq-ref arg 'score-system) all 1))
+     (mark-sys (or (assq-ref arg 'markup-system) all 1))
+     (score-mark (or (assq-ref arg 'score-markup) all 1))
+     (mark-mark (or (assq-ref arg 'markup-markup) all 1))
+     (top-sys (or (assq-ref arg 'top-system) all 1))
+     (top-mark (or (assq-ref arg 'top-markup) all 1))
+     (last-bot (or (assq-ref arg 'last-bottom) all 1)))
+    ;; Change settings by multiplying default values by the scaling factors.
+    ;; If the default value is 1, don't bother multiplying by 1.
+    #{
+      \paper {
+        system-system-spacing =
+        #`((basic-distance . ,(* 12 sys-sys))
+           (minimum-distance . ,(* 8 sys-sys))
+           (padding . ,sys-sys))
+        score-system-spacing =
+        #`((basic-distance . ,(* 14 score-sys))
+           (minimum-distance . ,(* 8 score-sys))
+           (padding . ,score-sys))
+        markup-system-spacing =
+        #`((basic-distance . ,(* 5 mark-sys))
+           (padding . ,(* 0.5 mark-sys)))
+        score-markup-spacing =
+        #`((basic-distance . ,(* 12 score-mark))
+           (padding . ,(* 0.5 score-mark)))
+        markup-markup-spacing =
+        #`((basic-distance . ,mark-mark)
+           (padding . ,(* 0.5 mark-mark)))
+        top-system-spacing =
+        % top-system-spacing: minimum-distance is 0
+        #`((basic-distance . ,top-sys)
+           (padding . ,top-sys))
+        top-markup-spacing.padding = #top-mark
+        % top-markup-spacing: basic-distance and minimum-distance are 0
+        last-bottom-spacing =
+        % last-bottom-spacing: minimum-distance is 0
+        #`((basic-distance . ,last-bot)
+           (padding . ,last-bot))
+      }
+    #}))
+
+
+scaleVerticalSpacingInSystems =
+#(define-scheme-function (parser location arg) (number-or-list?)
+   "Multiplies the default values of the grob-properties that affect 
+    flexible vertical spacing within systems by the amounts specified 
+    in @{arg}, a number or alist.  Returns a layout block."
+   ;; FretBoards do not set any grob-properties in VerticalAxisGroup,
+   ;; so there's nothing to scale for them, so they are not included.
+   (let*
+    ;; Get scaling factors from arg.
+    ((all (or (assq-ref arg 'all) (if (number? arg) arg)))
+     (grp (or (assq-ref arg 'staff-grouper) all))
+     (stf (or (assq-ref arg 'staff) (assq-ref arg 'staff-default-staff-staff) all))
+     (crds (or (assq-ref arg 'chord-names) all))
+     (dyn (or (assq-ref arg 'dynamics) (assq-ref arg 'dynamics-nonstaff-relatedstaff) all))
+     (figb (or (assq-ref arg 'figured-bass) all))
+     (lyr (or (assq-ref arg 'lyrics) all))
+     (nn (or (assq-ref arg 'note-names) all))
+
+     (grp-staff-staff (or (assq-ref arg 'StaffGrouper.staff-staff) grp))
+     (grp-grp-staff (or (assq-ref arg 'StaffGrouper.staffgroup-staff) grp))
+     (crds-non-rel (or (assq-ref arg 'chord-names-nonstaff-relatedstaff) crds))
+     (crds-non-non (or (assq-ref arg 'chord-names-nonstaff-nonstaff) crds))
+     (figb-non-rel (or (assq-ref arg 'figured-bass-nonstaff-relatedstaff) figb))
+     (figb-non-non (or (assq-ref arg 'figured-bass-nonstaff-nonstaff) figb))
+     (lyr-non-rel (or (assq-ref arg 'lyrics-nonstaff-relatedstaff) lyr))
+     (lyr-non-non (or (assq-ref arg 'lyrics-nonstaff-nonstaff) lyr))
+     (lyr-non-un (or (assq-ref arg 'lyrics-nonstaff-unrelatedstaff) lyr))
+     (nn-non-rel (or (assq-ref arg 'note-names-nonstaff-relatedstaff) nn))
+     (nn-non-non (or (assq-ref arg 'note-names-nonstaff-nonstaff) nn))
+     (nn-non-un (or (assq-ref arg 'note-names-nonstaff-unrelatedstaff) nn)))
+    ;; Create overrides by multiplying default values by the scaling factors.
+    ;; If the default value is 1, don't bother multiplying by 1.
+    #{
+      \layout {
+        \context {
+          \Score {
+            #(if grp-staff-staff #{
+              \override StaffGrouper.staff-staff-spacing =
+              #`((basic-distance . ,(* 9 grp-staff-staff))
+                 (minimum-distance . ,(* 7 grp-staff-staff))
+                 (padding . ,grp-staff-staff))
+                 #})
+            #(if grp-grp-staff #{
+              \override StaffGrouper.staffgroup-staff-spacing =
+              #`((basic-distance . ,(* 10.5 grp-grp-staff))
+                 (minimum-distance . ,(* 8 grp-grp-staff))
+                 (padding . ,grp-grp-staff))
+                 #})
+          }
+        }
+        \context {
+          \Staff {
+            #(if stf #{
+              \override VerticalAxisGroup.default-staff-staff-spacing =
+              #`((basic-distance . ,(* 9 stf))
+                 (minimum-distance . ,(* 8 stf))
+                 (padding . ,stf))
+                 #})
+          }
+        }
+        \context {
+          \ChordNames {
+            #(if crds-non-rel #{
+              \override VerticalAxisGroup.nonstaff-relatedstaff-spacing.padding =
+              #(* 0.5 crds-non-rel)
+                 #})
+            #(if crds-non-non #{
+              \override VerticalAxisGroup.nonstaff-nonstaff-spacing.padding =
+              #(* 0.5 crds-non-non)
+                 #})
+          }
+        }
+        \context {
+          \Dynamics {
+            #(if dyn #{
+              \override VerticalAxisGroup.nonstaff-relatedstaff-spacing =
+              #`((basic-distance . ,(* 5 dyn))
+                 (padding . ,(* 0.5 dyn)))
+                 #})
+          }
+        }
+        \context {
+          \FiguredBass {
+            #(if figb #{
+              \override VerticalAxisGroup.nonstaff-relatedstaff-spacing.padding =
+              #(* 0.5 figb-non-rel)
+                 #})
+            #(if figb #{
+              \override VerticalAxisGroup.nonstaff-nonstaff-spacing.padding =
+              #(* 0.5 figb-non-non)
+                 #})
+          }
+        }
+        \context {
+          \Lyrics {
+            #(if lyr-non-rel #{
+              \override VerticalAxisGroup.nonstaff-relatedstaff-spacing =
+              #`((basic-distance . ,(* 5.5 lyr-non-rel))
+                 (padding . ,(* 0.5 lyr-non-rel)))
+                 #})
+            #(if lyr-non-non #{
+              \override VerticalAxisGroup.nonstaff-nonstaff-spacing =
+              % basic-distance is 0
+              #`((minimum-distance . ,(* 2.8 lyr-non-non))
+                 (padding . ,(* 0.2 lyr-non-non)))
+                 #})
+            #(if lyr-non-un #{
+              \override VerticalAxisGroup.nonstaff-unrelatedstaff-spacing.padding =
+              #(* 1.5 lyr-non-un)
+                 #})
+          }
+        }
+        \context {
+          \NoteNames {
+            #(if nn-non-rel #{
+              \override VerticalAxisGroup.nonstaff-relatedstaff-spacing =
+              #`((basic-distance . ,(* 5.5 nn-non-rel))
+                 (padding . ,(* 0.5 nn-non-rel)))
+                 #})
+            #(if nn-non-non #{
+              \override VerticalAxisGroup.nonstaff-nonstaff-spacing =
+              % basic-distance is 0
+              #`((minimum-distance . ,(* 2.8 nn-non-non))
+                 (padding . ,(* 0.2 nn-non-non)))
+                 #})
+            #(if nn-non-un #{
+              \override VerticalAxisGroup.nonstaff-unrelatedstaff-spacing.padding =
+              #(* 1.5 nn-non-un)
+                 #})
+          }
+        }
+      }
+    #}))
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%
+% EXAMPLE USAGE
+% GOOD FOR CUTTING AND PASTING
+%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+
+% A1. scale all page layout variables by the same amount
+\scaleVerticalSpacingPageLayout #1.5
+
+% A2. scale specific page layout variables
+\scaleVerticalSpacingPageLayout
+#'((all . 1)
+   (system-system . 1)
+   (score-system . 1)
+   (markup-system . 1)
+   (score-markup . 1)
+   (markup-markup . 1)
+   (top-system . 1)
+   (top-markup . 1)
+   (last-bottom . 1))
+
+% B1. scale all properties by the same amount
+\scaleVerticalSpacingInSystems #1.5
+
+% B2. scale properties for specific contexts
+% (or of the StaffGrouper grob, which is not a context)
+\scaleVerticalSpacingInSystems
+#'((all . 1)
+   (staff-grouper . 1)
+   (staff . 1)
+   (chord-names . 1)
+   (dynamics . 1)
+   (figured-bass . 1)
+   (lyrics . 1)
+   (note-names . 1))
+
+% B3. scale specific properties within specific contexts
+% (or of the StaffGrouper grob, which is not a context)
+\scaleVerticalSpacingInSystems
+#'((all . 1)
+   (staff-grouper-staff-staff . 1)
+   (staff-grouper-staffgroup-staff . 1)
+   (staff-default-staff-staff . 1) ;; same as (staff . 1)
+   (chord-names-nonstaff-relatedstaff . 1)
+   (chord-names-nonstaff-nonstaff . 1)
+   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
+   (figured-bass-nonstaff-relatedstaff . 1)
+   (figured-bass-nonstaff-nonstaff . 1)
+   (lyrics-nonstaff-relatedstaff . 1)
+   (lyrics-nonstaff-nonstaff . 1)
+   (lyrics-nonstaff-unrelatedstaff . 1)
+   (note-names-nonstaff-relatedstaff . 1)
+   (note-names-nonstaff-nonstaff . 1)
+   (note-names-nonstaff-unrelatedstaff . 1))
+
+% B2 & B3
+\scaleVerticalSpacingInSystems
+#'((all . 1)
+   (staff-grouper . 1)
+   (staff . 1)
+   (chord-names . 1)
+   (dynamics . 1)
+   (figured-bass . 1)
+   (lyrics . 1)
+   (note-names . 1)
+   (staff-grouper-staff-staff . 1)
+   (staff-grouper-staffgroup-staff . 1)
+   (staff-default-staff-staff . 1) ;; same as (staff . 1)
+   (chord-names-nonstaff-relatedstaff . 1)
+   (chord-names-nonstaff-nonstaff . 1)
+   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
+   (figured-bass-nonstaff-relatedstaff . 1)
+   (figured-bass-nonstaff-nonstaff . 1)
+   (lyrics-nonstaff-relatedstaff . 1)
+   (lyrics-nonstaff-nonstaff . 1)
+   (lyrics-nonstaff-unrelatedstaff . 1)
+   (note-names-nonstaff-relatedstaff . 1)
+   (note-names-nonstaff-nonstaff . 1)
+   (note-names-nonstaff-unrelatedstaff . 1))
+
+%}

--- a/notation-snippets/scale-vertical-spacing/example.ly
+++ b/notation-snippets/scale-vertical-spacing/example.ly
@@ -1,0 +1,116 @@
+\version "2.19.13"
+
+\include "./definitions.ily"
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% This example shows how "Scale vertical spacing" can be used.
+% The implementation is in the file
+% `definitions.ily`.
+% Documentation (if any) should be in `README.md`.
+
+% A1. scale all page layout variables by the same amount
+\scaleVerticalSpacingPageLayout #1.5
+
+%{
+
+% A2. scale specific page layout variables
+\scaleVerticalSpacingPageLayout
+#'((all . 1)
+   (system-system . 1)
+   (score-system . 1)
+   (markup-system . 1)
+   (score-markup . 1)
+   (markup-markup . 1)
+   (top-system . 1)
+   (top-markup . 1)
+   (last-bottom . 1))
+
+%}
+
+% B1. scale all properties by the same amount
+\scaleVerticalSpacingInSystems #1.5
+
+%{
+
+% B2. scale properties for specific contexts
+% (or of the StaffGrouper grob, which is not a context)
+\scaleVerticalSpacingInSystems
+#'((all . 1)
+   (staff-grouper . 1)
+   (staff . 1)
+   (chord-names . 1)
+   (dynamics . 1)
+   (figured-bass . 1)
+   (lyrics . 1)
+   (note-names . 1))
+
+% B3. scale specific properties within specific contexts
+% (or of the StaffGrouper grob, which is not a context)
+\scaleVerticalSpacingInSystems
+#'((all . 1)
+   (staff-grouper-staff-staff . 1)
+   (staff-grouper-staffgroup-staff . 1)
+   (staff-default-staff-staff . 1) ;; same as (staff . 1)
+   (chord-names-nonstaff-relatedstaff . 1)
+   (chord-names-nonstaff-nonstaff . 1)
+   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
+   (figured-bass-nonstaff-relatedstaff . 1)
+   (figured-bass-nonstaff-nonstaff . 1)
+   (lyrics-nonstaff-relatedstaff . 1)
+   (lyrics-nonstaff-nonstaff . 1)
+   (lyrics-nonstaff-unrelatedstaff . 1)
+   (note-names-nonstaff-relatedstaff . 1)
+   (note-names-nonstaff-nonstaff . 1)
+   (note-names-nonstaff-unrelatedstaff . 1))
+
+% B2 & B3
+\scaleVerticalSpacingInSystems
+#'((all . 1)
+   (staff-grouper . 1)
+   (staff . 1)
+   (chord-names . 1)
+   (dynamics . 1)
+   (figured-bass . 1)
+   (lyrics . 1)
+   (note-names . 1)
+   (staff-grouper-staff-staff . 1)
+   (staff-grouper-staffgroup-staff . 1)
+   (staff-default-staff-staff . 1) ;; same as (staff . 1)
+   (chord-names-nonstaff-relatedstaff . 1)
+   (chord-names-nonstaff-nonstaff . 1)
+   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
+   (figured-bass-nonstaff-relatedstaff . 1)
+   (figured-bass-nonstaff-nonstaff . 1)
+   (lyrics-nonstaff-relatedstaff . 1)
+   (lyrics-nonstaff-nonstaff . 1)
+   (lyrics-nonstaff-unrelatedstaff . 1)
+   (note-names-nonstaff-relatedstaff . 1)
+   (note-names-nonstaff-nonstaff . 1)
+   (note-names-nonstaff-unrelatedstaff . 1))
+
+%}
+
+% EXAMPLE MUSIC
+
+global = { \key c \major \time 4/4 }
+somenotes = \repeat unfold 48 { c8[ c] }
+chordNames = \chordmode { \global \repeat unfold 12 { c1:m } }
+melody = \relative c'' { \global \somenotes }
+verse = \lyricmode { \repeat unfold 48 { la la } }
+right = \relative c'' { \global \somenotes }
+left = \relative c' { \global \somenotes }
+
+\score {
+  <<
+    <<
+      \new ChordNames \chordNames
+      \new Staff { \melody }
+      \addlyrics { \verse }
+    >>
+    \new PianoStaff <<
+      \new Staff = "right" { \right }
+      \new Staff = "left" { \clef bass \left }
+    >>
+  >>
+  \layout { }
+}

--- a/notation-snippets/scale-vertical-spacing/example.ly
+++ b/notation-snippets/scale-vertical-spacing/example.ly
@@ -4,91 +4,20 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % This example shows how "Scale vertical spacing" can be used.
-% The implementation is in the file
+% The implementation and some basic documentation is in the file
 % `definitions.ily`.
-% Documentation (if any) should be in `README.md`.
 
-% A1. scale all page layout variables by the same amount
+% scale all page layout variables by the same amount
+
 \scaleVerticalSpacingPageLayout #1.5
 
-%{
+% scale all "in-system" properties by the same amount,
+% except for lyrics, which is scaled by a different amount
 
-% A2. scale specific page layout variables
-\scaleVerticalSpacingPageLayout
-#'((all . 1)
-   (system-system . 1)
-   (score-system . 1)
-   (markup-system . 1)
-   (score-markup . 1)
-   (markup-markup . 1)
-   (top-system . 1)
-   (top-markup . 1)
-   (last-bottom . 1))
-
-%}
-
-% B1. scale all properties by the same amount
-\scaleVerticalSpacingInSystems #1.5
-
-%{
-
-% B2. scale properties for specific contexts
-% (or of the StaffGrouper grob, which is not a context)
 \scaleVerticalSpacingInSystems
-#'((all . 1)
-   (staff-grouper . 1)
-   (staff . 1)
-   (chord-names . 1)
-   (dynamics . 1)
-   (figured-bass . 1)
-   (lyrics . 1)
-   (note-names . 1))
+#'((all . 1.5)
+   (lyrics . 1.15))
 
-% B3. scale specific properties within specific contexts
-% (or of the StaffGrouper grob, which is not a context)
-\scaleVerticalSpacingInSystems
-#'((all . 1)
-   (staff-grouper-staff-staff . 1)
-   (staff-grouper-staffgroup-staff . 1)
-   (staff-default-staff-staff . 1) ;; same as (staff . 1)
-   (chord-names-nonstaff-relatedstaff . 1)
-   (chord-names-nonstaff-nonstaff . 1)
-   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
-   (figured-bass-nonstaff-relatedstaff . 1)
-   (figured-bass-nonstaff-nonstaff . 1)
-   (lyrics-nonstaff-relatedstaff . 1)
-   (lyrics-nonstaff-nonstaff . 1)
-   (lyrics-nonstaff-unrelatedstaff . 1)
-   (note-names-nonstaff-relatedstaff . 1)
-   (note-names-nonstaff-nonstaff . 1)
-   (note-names-nonstaff-unrelatedstaff . 1))
-
-% B2 & B3
-\scaleVerticalSpacingInSystems
-#'((all . 1)
-   (staff-grouper . 1)
-   (staff . 1)
-   (chord-names . 1)
-   (dynamics . 1)
-   (figured-bass . 1)
-   (lyrics . 1)
-   (note-names . 1)
-   (staff-grouper-staff-staff . 1)
-   (staff-grouper-staffgroup-staff . 1)
-   (staff-default-staff-staff . 1) ;; same as (staff . 1)
-   (chord-names-nonstaff-relatedstaff . 1)
-   (chord-names-nonstaff-nonstaff . 1)
-   (dynamics-nonstaff-relatedstaff . 1) ;; same as (dynamics . 1)
-   (figured-bass-nonstaff-relatedstaff . 1)
-   (figured-bass-nonstaff-nonstaff . 1)
-   (lyrics-nonstaff-relatedstaff . 1)
-   (lyrics-nonstaff-nonstaff . 1)
-   (lyrics-nonstaff-unrelatedstaff . 1)
-   (note-names-nonstaff-relatedstaff . 1)
-   (note-names-nonstaff-nonstaff . 1)
-   (note-names-nonstaff-unrelatedstaff . 1))
-
-%}
 
 % EXAMPLE MUSIC
 


### PR DESCRIPTION
Provides an easier way to adjust vertical spacing, letting you scale the default settings, see:
http://lilypond.org/doc/v2.18/Documentation/notation/flexible-vertical-spacing-paper-variables
http://lilypond.org/doc/v2.18/Documentation/notation/flexible-vertical-spacing-within-systems
