### PR TITLE
Load the edition-engraver only once

### DIFF
--- a/editorial-tools/edition-engraver/definitions.ily
+++ b/editorial-tools/edition-engraver/definitions.ily
@@ -14,5 +14,12 @@
   status = "ready"
 }
 
+#(cond ((not (defined? 'edition-engraver-loaded))
+        (define edition-engraver-loaded #f)))
+
 % import the edition-engraver from the corresponding scheme-module
-#(use-modules (editorial-tools edition-engraver module))
+% but only if it hasn't already been loaded
+#(if (not edition-engraver-loaded)
+     (begin
+      (use-modules (editorial-tools edition-engraver module))
+      (set! edition-engraver-loaded #t)))


### PR DESCRIPTION
As I intend to create more functions using the edition-engraver
I think it should be ensured that it will be loaded only once.
However, I'm not sure if (use-modules) doesn't do that already.
