### PR TITLE
edition-engraver: Syntactic sugar for editionModList

### DIFF
--- a/editorial-tools/edition-engraver/module.scm
+++ b/editorial-tools/edition-engraver/module.scm
@@ -484,11 +484,12 @@
 
 
 (define (memom? v)
-  (and (pair? v)(integer? (car v))
-       (let ((cv (cdr v)))
-         (if (list? cv)(set! cv (car cv)))
-         (or (rational? cv)(frac-or-mom? cv))
-         )))
+  (or (integer? v)
+      (and (pair? v)(integer? (car v))
+           (let ((cv (cdr v)))
+             (if (list? cv)(set! cv (car cv)))
+             (or (rational? cv)(frac-or-mom? cv))
+             ))))
 (define (limemom? v)(and (list? v)(every memom? v)))
 
 ;%%% the key function "editionMMod"
@@ -517,14 +518,17 @@
     (let ((path (create-music-path #f path)))
       (for-each
        (lambda (p)
-         (let ((takt (car p))
-               (pos (cdr p)))
-           (if (list? pos)(set! pos (car pos)))
-           (if (fraction? pos)(set! pos (fraction->moment pos)))
-           (if (rational? pos)
-               (set! pos (ly:make-moment (numerator pos)(denominator pos))))
-           (add-edmod edition takt pos path mod)
-           )) mposl)
+         (begin
+          (if (integer? p)(set! p (list p 0)))
+          (let ((takt (car p))
+                (pos (cdr p)))
+            (if (integer? pos)(set! pos (list pos 0)))
+            (if (list? pos)(set! pos (car pos)))
+            (if (fraction? pos)(set! pos (fraction->moment pos)))
+            (if (rational? pos)
+                (set! pos (ly:make-moment (numerator pos)(denominator pos))))
+            (add-edmod edition takt pos path mod)
+            ))) mposl)
       )))
 
 

--- a/editorial-tools/edition-engraver/module.scm
+++ b/editorial-tools/edition-engraver/module.scm
@@ -483,7 +483,7 @@
     ))
 
 
-(define (memom? v)
+(define-public (memom? v)
   (or (integer? v)
       (and (pair? v)(integer? (car v))
            (let ((cv (cdr v)))


### PR DESCRIPTION
\editionModList entries can now also contain plain integers
which are automatically extended to refer to the first beat of
the given measure.

`#'(11 15 (17 2/4))`

will now be accepted and apply the mods at

`#'((11 0/4) (15 0/4) (17 2/4))`
