### PR TITLE
oll: let get-a-tree return unspecified

### DIFF
--- a/ly/_internal/utilities/alist-access.ily
+++ b/ly/_internal/utilities/alist-access.ily
@@ -101,8 +101,11 @@
                  (getval al (cdr op))
                  #f)))
           ((= (length op) 1)
-           (assoc-get (car op) ol #f))
-          (else #f))))
+           (let ((valpair (assoc (car op) ol)))
+             (if valpair
+                 (cdr valpair)
+                 ; return unspecified if key is not present
+                 ))))))
      (if (list? opts)
          (getval opts path)
          (begin


### PR DESCRIPTION
If trying to retrieve a value from an alist and the key
isn't present get-a-tree would now return `#<unspecified>`.

I'm not sure about the implications on existing code, but
it will be more consistent because the caller can now
distinguish between non-existent keys and keys with the value
# f.

Fixes #68
