### PR TITLE
test: route to new Travis build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@
 
 language: python
 
+# This will route the build job to the new Travis build environment
+sudo: false
+
 # This is the script that will actually run the tests
 script: ./test/simple_tests.py
 


### PR DESCRIPTION
according to Travis support "sudo:false" should be used
when "sudo" isn't needed.
