### PR TITLE
test: Add CI status image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/openlilylib/openlilylib.svg?branch=master)](https://travis-ci.org/openlilylib/openlilylib)
+
 What's this?
 ============
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+Build Status of `openLilyLib` on [Travis](https://travis-ci.org/openlilylib/openlilylib)  
 [![Build Status](https://travis-ci.org/openlilylib/openlilylib.svg?branch=master)](https://travis-ci.org/openlilylib/openlilylib)
 
 What's this?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Build Status of `openLilyLib` on [Travis](https://travis-ci.org/openlilylib/openlilylib)  
+Build Status of `openLilyLib` on [Travis](https://travis-ci.org/openlilylib/openlilylib):
 [![Build Status](https://travis-ci.org/openlilylib/openlilylib.svg?branch=master)](https://travis-ci.org/openlilylib/openlilylib)
 
 What's this?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Build Status of `openLilyLib` on [Travis](https://travis-ci.org/openlilylib/openlilylib):
+Build Status of `openLilyLib` on Travis:  
 [![Build Status](https://travis-ci.org/openlilylib/openlilylib.svg?branch=master)](https://travis-ci.org/openlilylib/openlilylib)
 
 What's this?


### PR DESCRIPTION
Travis CI supports status images that reflect the build status
of the latest commit. Having it in the README allows
the users to be sure that they are checking out working
code.
