### PR TITLE
test: define results dir (to be discussed)

### DIFF
--- a/test/TEST-RESULTS.md
+++ b/test/TEST-RESULTS.md
@@ -1,0 +1,12 @@
+Results of automated tests in openLilyLib
+=========================================
+
+The `results` directory holds test results produced by the `openLilyLib` automated
+test suite. After the tests have been completed successfully the result
+files can be picked up to generate documentation.
+
+The result files are written to a directory structure representing that of the
+original `openLilyLib` hierarchy, `results` corresponding to the root directory.
+
+Before the tests start the directory is cleared completely, so please don't
+store anything in there manually.

--- a/test/simple_tests.py
+++ b/test/simple_tests.py
@@ -69,7 +69,9 @@ class SimpleTests:
 
         self.lily_command_with_includes = [self.lily_command,
                    "-I", self.openlilylib_dir,
-                   "-I", os.path.join(self.openlilylib_dir, "ly")]
+                   "-I", os.path.join(self.openlilylib_dir, "ly"),
+                   "-o",
+                   os.path.join(self.openlilylib_dir, "test", "results")]
 
         self.test_files = []
         self.included_tests = []

--- a/test/simple_tests.py
+++ b/test/simple_tests.py
@@ -69,14 +69,21 @@ class SimpleTests:
 
         self.lily_command_with_includes = [self.lily_command,
                    "-I", self.openlilylib_dir,
-                   "-I", os.path.join(self.openlilylib_dir, "ly"),
-                   "-o",
-                   os.path.join(self.openlilylib_dir, "test", "results")]
+                   "-I", os.path.join(self.openlilylib_dir, "ly")]
 
         self.test_files = []
         self.included_tests = []
         self.excluded_tests = []
 
+
+    def clean_results_dir(self):
+        results_dir = os.path.join(self.openlilylib_dir,
+                                   "test",
+                                   "results",
+                                   self.lilypond_version)
+        if os.path.exists(results_dir):
+            print "Removing result dir:",results_dir
+            shutil.rmtree(results_dir)
 
     def clean_tmp_dir(self):
         if os.path.exists(self.tmp_lily_dir):
@@ -225,7 +232,16 @@ class SimpleTests:
         failed_tests = {}
         for test in self.test_files:
             print "\n\nRunning test", self.__relative_path(test)
-            lily = sp.Popen(self.lily_command_with_includes + [test],
+            test_dir = os.path.join(self.openlilylib_dir,
+                                    "test",
+                                    "results",
+                                    self.lilypond_version,
+                                    os.path.dirname(self.__relative_path(test)))
+            if not os.path.exists(test_dir):
+                os.makedirs(test_dir)
+            lily = sp.Popen(self.lily_command_with_includes + ['-o',
+                                                               test_dir,
+                                                               test],
                             stdout=sp.PIPE, stderr=sp.PIPE)
             (out, err) = lily.communicate()
             if lily.returncode != 0:
@@ -274,4 +290,6 @@ if __name__ == "__main__":
     print "LilyPond command to be used:"
     print " ".join(tests.lily_command_with_includes + ["<test-file>"])
 
+    print "\nClear previous test results (if any)."
+    tests.clean_results_dir()
     tests.run()


### PR DESCRIPTION
Previously test results were written to the working directory,
which is not good.
This commit defines a directory test/results where everything goes.

However, I'm not sure about it because that would mean we would
impose the requirement of unique file names throughout the whole
openLilyLib directory structure.

So the question is: Should results go beside the test files?
This would easily be doable by dynamically generating the -o
parameter.
