### PR TITLE
Pull lalily code in os-path module

### DIFF
--- a/ly/_internal/init-openlilylib.ily
+++ b/ly/_internal/init-openlilylib.ily
@@ -67,7 +67,7 @@
 % because that's inside the desired root directory
 setRootPath =
 #(define-void-function (parser location)()
-   (let* ((path (get-normalized-path (ly:input-file-line-char-column location))))
+   (let* ((path (location-extract-path location)))
      #{ \registerOption global.root-path #path #}
      (if (not (member path %load-path))
          (set! %load-path `(,path ,@%load-path)))))

--- a/ly/_internal/utilities/include-pattern.ily
+++ b/ly/_internal/utilities/include-pattern.ily
@@ -1,7 +1,5 @@
 \version "2.18.0"
 
-#(use-modules (scheme-lib lalily parser-location))
-
 \header {
   oll-title = "Include multiple files"
   oll-author = "Jan-Peter Voigt"

--- a/ly/_internal/utilities/os-path.ily
+++ b/ly/_internal/utilities/os-path.ily
@@ -45,26 +45,24 @@
        #\\
        #\/ ))
 
-#(define-public (split-path path-string)
-   "Return a list from a given path string,
-    respecting the OS dependent path separator."
-   (string-split path-string os-path-separator))
+#(define-public (split-path path)
+   "Returns a list with path elements.
+    Takes either a path string or a list.
+    If 'path' is a string it is split
+    respecting the OS dependent path separator,
+    if it is a list then simply the list is returned."
+   (if (string? path)
+       (string-split path os-path-separator)
+       path))
 
 #(define-public (get-cwd-list)
    "Return the current working directory as a list of strings."
    (split-path (getcwd)))
 
-#(define (make-path-list path)
-   "Take a path as a string or a string list and
-    return a string list"
-   (if (string? path)
-       (split-path path)
-       path))
-
 #(define-public (absolute-path? path)
    "Test if the given path is absolute.
     Process either a string or a string list."
-   (let ((path-list (make-path-list path)))
+   (let ((path-list (split-path path)))
      (if (and (> (length path-list) 0)
               ;; consider the path absolute if either the regex for windows volumes is matched
               ;; or the first list element is empty (indicating a "/" unix root)
@@ -79,7 +77,7 @@
     if it is a list a list is returned.
     The input string is OS independent (takes os-dependent path separator)
     but the resulting string is Unix-like (because this is nearly always what we need."
-   (let* ((path-list (make-path-list path))
+   (let* ((path-list (split-path path))
           (normalized
            (let ((ret '()))
              (for-each
@@ -100,7 +98,7 @@
     to the current working directory.
     Input is OS independent, output is Unix style."
    (let* ((is-string (string? path))
-          (path-list (make-path-list path))
+          (path-list (split-path path))
           (abs-path
            (if (absolute-path? path-list)
                path-list

--- a/ly/_internal/utilities/os-path.ily
+++ b/ly/_internal/utilities/os-path.ily
@@ -45,14 +45,14 @@
        #\\
        #\/ ))
 
-#(define-public (get-cwd-list)
-   "Return the current working directory as a list of strings."
-   (string-split (getcwd) os-path-separator))
-
 #(define-public (split-path path-string)
    "Return a list from a given path string,
     respecting the OS dependent path separator."
    (string-split path-string os-path-separator))
+
+#(define-public (get-cwd-list)
+   "Return the current working directory as a list of strings."
+   (split-path (getcwd)))
 
 #(define (make-path-list path)
    "Take a path as a string or a string list and

--- a/scheme-lib/lalily/parser-location.scm
+++ b/scheme-lib/lalily/parser-location.scm
@@ -32,6 +32,23 @@
     (regexp-match? (string-match (format "^(.*/)?~A\\.i?ly$" outname) locname))
     ))
 
+;
+; All of the following is deprecated
+; as the functionality has been moved to
+; ly/_internal/utilities/os-path.ily.
+;
+; There it is much more consistently named and handled,
+; and a number of code duplicates have been harmonized.
+; as soon as it is clear what should be done with lalily-test-location?
+; the complete file should officially be deprecated.
+;
+; This deprecation must be used more carefully (i.e. by only
+; printing a warning) because code dependencies may be much
+; more common and complex than with simply moving a file into
+; the new structure (which is because the move goes along with
+; significant rewrite).
+;
+
 (define-public (listcwd) '())
 (define-public (absolutePath? path) #f)
 (let* ((os (getenv "OS"))


### PR DESCRIPTION
These commits pull code from `scheme-lib/lalily/parser-location.scm` into `ly/_internal/utilities/os-path.ily`.
This module is loaded implicitly with openLilyLib

To some extent this file is similar to Python's os.path module.

When collecting code from this lalily module it became clear that there are quite some inconsistencies and redundancies in the lalily modules, and this Pull Request tries to leverage this issue. However this means that the interface changes significantly, and therefore I haven't removed the old functions yet. Instead the only thing is a warning that is printed whenever the old file is included.

Someone should take a look at possible dependencies and decide wheter the content of `scheme-lib/lalily/parser-location.scm` can be removed.
