### PR TITLE
oll: Fix call to old listcwd

### DIFF
--- a/ly/_internal/utilities/os-path.scm
+++ b/ly/_internal/utilities/os-path.scm
@@ -97,8 +97,8 @@
           (let ((ret '()))
             (for-each
              (lambda (e)
-               (set! ret (cond ((equal? e "..")(if (> (length ret) 1) (cdr ret) (cdr (reverse (listcwd)))))
-                           ((equal? e ".") (if (= (length ret) 0) (reverse (listcwd)) ret))
+               (set! ret (cond ((equal? e "..")(if (> (length ret) 1) (cdr ret) (cdr (reverse (get-cwd-list)))))
+                           ((equal? e ".") (if (= (length ret) 0) (reverse (get-cwd-list)) ret))
                            (else `(,e ,@ret))))) path-list)
             (reverse ret))))
     (if (string? path)


### PR DESCRIPTION
listcwd isn't used anymore in the new openLilyLib infrastructure.
Two instances of the old call have survived from copy&Paste import.
Presumably because they are in a conditional that hasn't been executed
during any tests.

Fixes #95
