### PR TITLE
Stylesheets

### DIFF
--- a/ly/stylesheets/README.md
+++ b/ly/stylesheets/README.md
@@ -43,6 +43,7 @@ by using the following form:
 \useNotationFont \with {
   brace = Beethoven
   style = none
+  extensions = ##t
 }
 Cadence
 ```
@@ -55,3 +56,7 @@ notation font does not have a corresponding brace font (which is currently the c
 Using `none` as `style` will skip loading a stylesheet, which you may want when creating a style sheet
 from scratch. Please consult the documentation about any additional styles available for a given font.
 if a non-existent stylesheet is requested a warning is issued and the default stylesheet is loaded.
+
+A font may contain extensions that can be activated with the `extensions = ##t` option. Currently only
+the *Arnold* fonts has such extensions, consisting of a few extra articulations and commands.
+Requesting extensions for a font that doesn't provide them will issue a warning but don't do any further harm.

--- a/ly/stylesheets/README.md
+++ b/ly/stylesheets/README.md
@@ -1,0 +1,57 @@
+Stylesheets
+===========
+
+A library to manage font selection and stylesheets with the [GNU LilyPond](http://lilypond.org) music typesetter.
+This library is part of [openLilyLib](https://github.com/openlilylib/openlilylib) and maintained by
+
+- Urs Liska (ul@openlilylib.org)
+- Kieren MacMillan (kieren_macmillan@sympatico.ca)
+- Abraham Lee (tisimst.lilypond@gmail.com)
+
+---
+
+Initially only loading of alternative fonts for LilyPond is implemented, but this is already a great enhancement.
+On http://fonts.openlilylib.org a comprehensive range of alternative notation fonts is available for download. 
+If you have installed `openLilyLib` you can ignore the documentation with regard to the *usage* of the fonts,
+once you have downloaded and installed them. Very soon a Python script will available as part of this library
+that will make the process of downloading, updating and "installing" the fonts a nearly automatic process too.
+
+Using Alternative Fonts
+-----------------------
+
+The easiest way to use an alternative notation font in LilyPond is:
+
+```lilypond
+\version "2.19.12"
+
+\include "openlilylib"
+\loadModule "stylesheets"
+\useNotationFont Cadence
+```
+
+which will set up everything correctly to use "Cadence" as your document's notation font.
+Font names are case insensitive (so other than with the manual activation you don't need to
+write `cadence` here, and note that when the font name doesn't contain "illegal" characters
+(which currently only is the case with `Gutenberg1939`) you don't need quotation marks.
+
+The "simple" form of `\useNotationFont` uses the same name for notation and brace fonts and loads
+a default stylesheet that accompanies each font, adjusting LilyPond's engraving settings (e.g.
+line thicknesses) to match the appearance of the font. However, you have more fine-grained control
+by using the following form:
+
+```lilypond
+\useNotationFont \with {
+  brace = Beethoven
+  style = none
+}
+Cadence
+```
+
+This will set the brace font to `Beethoven` and skip loading of a stylesheet. Using `none` for the
+`brace` option will use the default Emmentaler brace font, which is usually a good idea when the
+notation font does not have a corresponding brace font (which is currently the case with the 
+*Cadence*, *Paganini* and *Scorlatti* fonts).
+
+Using `none` as `style` will skip loading a stylesheet, which you may want when creating a style sheet
+from scratch. Please consult the documentation about any additional styles available for a given font.
+if a non-existent stylesheet is requested a warning is issued and the default stylesheet is loaded.

--- a/ly/stylesheets/__init__.ily
+++ b/ly/stylesheets/__init__.ily
@@ -1,0 +1,36 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Initialization of the Stylesheets library
+%}
+
+
+#(oll:log "Initialized Stylesheets~a" "")

--- a/ly/stylesheets/__main__.ily
+++ b/ly/stylesheets/__main__.ily
@@ -132,3 +132,16 @@ useNotationFont =
           (ly:gulp-file style-file)))
     (oll:log location (format "Associated \"~a\" stylesheet loaded successfully" style))
     ))
+
+
+%%%% ARNOLD extensions
+% The Arnold font provides a number of extra glyphs
+% This command loads a separate style sheet defining commands
+% and articulations to make use of these extra glyphs.
+useArnoldExtensions = 
+#(define-void-function (parser location)()
+   (ly:parser-include-string parser
+     (ly:gulp-file
+      (string-append
+       #{ \getOption global.root-path #}
+       "/stylesheets/fonts/arnold-extensions.ily"))))

--- a/ly/stylesheets/__main__.ily
+++ b/ly/stylesheets/__main__.ily
@@ -97,7 +97,7 @@ useNotationFont =
 #(define-void-function (parser location options name)
    ((ly:context-mod?) string?)
    (if (lilypond-less-than? "2.19.12")
-       (oll:warn location (format fonts-lily-version-warning 
+       (oll:warn location (format fonts-lily-version-warning
                      (lilypond-version))))
    (let*
     (
@@ -132,7 +132,9 @@ useNotationFont =
     ;; if 'none' is given as brace set to default "emmentaler"
     (if (and (assoc-ref options 'brace)
              (string=? "none" (assoc-ref options 'brace)))
-        (set! brace "Emmentaler"))
+        (begin
+         (set! brace "Emmentaler")
+         (set! use-brace "emmentaler")))
 
     ;; if a non-existent stylesheet is requested
     ;; issue a warning and reset to -default
@@ -170,13 +172,12 @@ useNotationFont =
         "/stylesheets/load-font")))
     (oll:log location
       (format "Font \"~a\" loaded successfully" name))
-    
+
     ;; try to load font extensions if requested
     (if extensions (use-font-extensions parser location name))
 
     ;; include the determined style file for the font
     ;; if not "none".
-    (ly:message style)
     (if (not (string=? "none" style))
         (ly:parser-include-string parser
           (ly:gulp-file style-file)))

--- a/ly/stylesheets/__main__.ily
+++ b/ly/stylesheets/__main__.ily
@@ -37,12 +37,33 @@
 % Place the call to it inside a \paper {} block.
 \paper {
   useNotationFont =
-  #(define-scheme-function (parser location name)
-     (string?)
-     (ly:parser-define! parser 'fonts
-       (set-global-fonts
-        #:music name
-        #:brace name
-        #:factor (/ staff-height pt 20))))
+  #(define-scheme-function (parser location options name)
+     ((ly:context-mod?) string?)
+     (let*
+      (
+        ;; create an alist with options if they are given.
+        ;; if the argument is not given or no options are defined
+        ;; we have an empty list.
+        (options
+         (if options
+             (map
+              (lambda (o)
+                (cons (cadr o) (caddr o)))
+              (ly:get-context-mods options))
+             '()))
+        ;; retrieve 'brace' name from options if given.
+        ;; if not given we assume the same as the notation font
+        (brace
+         (or (assoc-ref options 'brace)
+              name))
+        )
+      ;; if 'none' is given as brace set to default "emmentaler"
+      (if (string=? "none" (assoc-ref options 'brace))
+          (set! brace "emmentaler"))
+      (ly:parser-define! parser 'fonts
+        (set-global-fonts
+         #:music name
+         #:brace brace
+         #:factor (/ staff-height pt 20)))))
 }
 

--- a/ly/stylesheets/__main__.ily
+++ b/ly/stylesheets/__main__.ily
@@ -117,7 +117,8 @@ useNotationFont =
     ;; Post-process options
     ;;
     ;; if 'none' is given as brace set to default "emmentaler"
-    (if (string=? "none" (assoc-ref options 'brace))
+    (if (and (assoc-ref options 'brace)
+             (string=? "none" (assoc-ref options 'brace)))
         (set! brace "Emmentaler"))
 
     ;; if a non-existent stylesheet is requested

--- a/ly/stylesheets/__main__.ily
+++ b/ly/stylesheets/__main__.ily
@@ -33,29 +33,8 @@
   Currently only font selection is implemented
 %}
 
-% Use a notation font with or without options.
-% To be called as a toplevel command.
-% Arguments:
-% - options: ly:context-mod? ( a "\with {}" clause)
-%   - brace: define brace font
-%            - "none": default to Emmentaler
-%            - omitted: use the same as the font name
-%   - style: load a style sheet for the font
-%            - omitted: load the "-default" stylesheet
-%                       (has to be provided by the library)
-% - name: Font name
-%
-% All arguments are case insensitive, so "Emmentaler" is
-% equivalent to "emmentaler".
-% Note: If the names do not contain characters beyond alphabetical
-% and a hyphen (but no numbers), the quotation marks can be omitted,
-% so
-%    \useNotationFont Beethoven
-% is valid while with
-%    \useNotationFont "Gutenberg1939"
-% the quotation marks are needed.
 
-
+% Starting with some helper commands
 #(define (make-style-file name style)
    "Construct file name for included style sheet.
     Factored out because needed several times."
@@ -82,6 +61,27 @@
            (format "No extensions available for font \"~a\". Skipping." name))
          )))
 
+% Use a notation font with or without options.
+% To be called as a toplevel command.
+% Arguments:
+% - options: ly:context-mod? ( a "\with {}" clause)
+%   - brace: define brace font
+%            - "none": default to Emmentaler
+%            - omitted: use the same as the font name
+%   - style: load a style sheet for the font
+%            - omitted: load the "-default" stylesheet
+%                       (has to be provided by the library)
+% - name: Font name
+%
+% All arguments are case insensitive, so "Emmentaler" is
+% equivalent to "emmentaler".
+% Note: If the names do not contain characters beyond alphabetical
+% and a hyphen (but no numbers), the quotation marks can be omitted,
+% so
+%    \useNotationFont Beethoven
+% is valid while with
+%    \useNotationFont "Gutenberg1939"
+% the quotation marks are needed.
 
 useNotationFont =
 #(define-void-function (parser location options name)

--- a/ly/stylesheets/__main__.ily
+++ b/ly/stylesheets/__main__.ily
@@ -41,6 +41,8 @@
      ((ly:context-mod?) string?)
      (let*
       (
+        ;; Make font name case insensitive
+        (use-name (string-downcase name))
         ;; create an alist with options if they are given.
         ;; if the argument is not given or no options are defined
         ;; we have an empty list.
@@ -62,7 +64,7 @@
           (set! brace "emmentaler"))
       (ly:parser-define! parser 'fonts
         (set-global-fonts
-         #:music name
+         #:music use-name
          #:brace brace
          #:factor (/ staff-height pt 20)))))
 }

--- a/ly/stylesheets/__main__.ily
+++ b/ly/stylesheets/__main__.ily
@@ -33,6 +33,7 @@
   Currently only font selection is implemented
 %}
 
+\version "2.18.0"
 
 % Starting with some helper commands
 #(define (make-style-file name style)
@@ -45,6 +46,15 @@
     "-"
     (string-downcase style)
     ".ily"))
+
+% A string that is used to warn users who run an older
+% LilyPond version.
+#(define fonts-lily-version-warning "
+Loading alternative fonts requires LilyPond >= 2.19.12 or
+a patched version of LilyPond 2.18. You are running LilyPond ~a.
+If you receive an error message below please either upgrade to
+a current LilyPond version or install the patch as described on
+http://fonts.openlilylib.org.\n")
 
 %%%% activate font extensions
 % The Arnold font provides a number of extra glyphs, others may follow.
@@ -86,6 +96,9 @@
 useNotationFont =
 #(define-void-function (parser location options name)
    ((ly:context-mod?) string?)
+   (if (lilypond-less-than? "2.19.12")
+       (oll:warn location (format fonts-lily-version-warning 
+                     (lilypond-version))))
    (let*
     (
       (use-name (string-downcase name))

--- a/ly/stylesheets/__main__.ily
+++ b/ly/stylesheets/__main__.ily
@@ -1,0 +1,48 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Main functionality for font and stylesheet selection.
+  Currently only font selection is implemented
+%}
+
+% Wrapper around choosing notation fonts.
+% Place the call to it inside a \paper {} block.
+\paper {
+  useNotationFont =
+  #(define-scheme-function (parser location name)
+     (string?)
+     (ly:parser-define! parser 'fonts
+       (set-global-fonts
+        #:music name
+        #:brace name
+        #:factor (/ staff-height pt 20))))
+}
+

--- a/ly/stylesheets/fonts/arnold-default.ily
+++ b/ly/stylesheets/fonts/arnold-default.ily
@@ -1,0 +1,75 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Arnold font.
+  Mainly provided by Janek Warchoł and Urs Liska to match the appearance of
+  Universal Edition score of ca. 1910-1920
+%}
+
+\layout {
+
+  \context {
+    \Voice
+    \override Beam.beam-thickness = 0.52
+    \override Slur.thickness = 1.75
+    \override Slur.line-thickness = 0.6
+    \override Tie.thickness = 1.6
+    \override Tie.line-thickness = 0.6
+  }
+
+  \context {
+    \Lyrics
+    \override LyricText.font-size = 0.3
+    \override LyricText.stencil =
+    #(lambda (grob)
+       (ly:stencil-scale (lyric-text::print grob) 0.9 1))
+  }
+
+
+  \context {
+    \Score
+    \override DynamicText.font-size = 1.15
+    \override Stem.thickness = 1.15
+    \override Hairpin.thickness = 1.4
+    \override Hairpin.height = 0.45
+    \override InstrumentName.font-size = 1.5
+    \override MetronomeMark.font-size = 1.5
+    \override Glissando.thickness = 1.75
+    % This is a temporary modification.
+    % Squeezing the Century font makes the text fonts look
+    % surprisingly similar to the original UE fonts, but it
+    % is not ideal to scale the stencil as a whole becuause
+    % that also squeezes notation elements.
+    \override MetronomeMark.stencil =
+    #(lambda (grob)
+       (ly:stencil-scale (lyric-text::print grob) 0.78 1))
+  }
+}

--- a/ly/stylesheets/fonts/arnold-extensions.ily
+++ b/ly/stylesheets/fonts/arnold-extensions.ily
@@ -1,0 +1,116 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Some extensions that have been made possible through extra glyphs
+  in the Arnold font. Including this file and using its commands are
+  useless if Arnold has not been activated with \useNotationFont.
+
+  Additional articulations:
+  - \weakbeat
+  - \strongbeat
+  - \varaccent (alternative glyph for accent)
+
+  - \altAccent activates the varaccent to be used with -> or \accent
+  - \defAccent reverts to the normal accent glyph
+
+  Additional commands (implemented as markups)
+  They are structural elements in typical dodecaphonic scores.
+  - \hauptstimme
+  - \nebenstimme
+  - \endstimme
+
+  TODO: Consider changing these from markups to line spanners
+  as they are practically always coming in pairs.
+%}
+
+%%%% Add custom articulations with non-standard glyphs from Arnold
+%
+% TODO:
+% The properties for the articulations are completely arbitrary
+% and simply copied from arbitrary existing articulations.
+% TODO:
+% Change glyph names for 'varaccent' when changed in font
+% TODO:
+% Change the glyph scaling once this is done in the font
+
+#(append! default-script-alist
+   (list
+    `("weakbeat"
+       . ((script-stencil . (feta . ("weakbeat" . "weakbeat")))
+          (font-size . 1.5)
+          ; any other properties
+          (toward-stem-shift-in-column . 0.0)
+          (padding . 1)
+          (avoid-slur . around)
+          (direction . ,UP)))
+    `("strongbeat"
+       . ((script-stencil . (feta . ("strongbeat" . "strongbeat")))
+          ; any other properties
+          (font-size . -0.5)
+          (toward-stem-shift-in-column . 0.0)
+          (padding . 1)
+          (avoid-slur . around)
+          (direction . ,UP)))
+    `("varaccent"
+       . ((toward-stem-shift-in-column . 0.0)
+          (script-stencil . (feta . ("varsforzato" . "varsforzato")))
+          ; any other properties
+          (padding . 0.20)
+          (side-relative-direction . ,DOWN)
+          (avoid-slur . around)))
+    ))
+
+%%%% create postfix commands to use the articulations
+weakbeat = #(make-articulation "weakbeat")
+strongbeat = #(make-articulation "strongbeat")
+varaccent = #(make-articulation "varaccent")
+
+%%%% Switch between default and alternative accent glyphs.
+%%%% This can be changed during the music.
+% TODO:
+% Decide about the naming (altAccent is good but inconsistent)
+altAccent =
+#(define-void-function (parser location)()
+   (set! dashLarger varaccent))
+
+defAccent =
+#(define-void-function (parser location)()
+   (set! dashLarger accent))
+
+%%%% Add commands for typical Viennese School voicing indications
+% TODO
+% Check scaling once the glyphs have been updated in the font
+% And check glyph name of endstimme.
+scale-stimme = #-1.2
+
+hauptstimme = \markup { \fontsize #scale-stimme \halign #1 \musicglyph #"scripts.hauptstimme" }
+nebenstimme = \markup { \fontsize #scale-stimme \halign #1 \musicglyph #"scripts.nebenstimme" }
+endstimme = \markup { \fontsize #scale-stimme \halign #-1.5 \musicglyph #"scripts.endvoice" }

--- a/ly/stylesheets/fonts/beethoven-default.ily
+++ b/ly/stylesheets/fonts/beethoven-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Beethoven font.
+%}
+

--- a/ly/stylesheets/fonts/cadence-default.ily
+++ b/ly/stylesheets/fonts/cadence-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Cadence font.
+%}
+

--- a/ly/stylesheets/fonts/gonville-default.ily
+++ b/ly/stylesheets/fonts/gonville-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Gonville font.
+%}
+

--- a/ly/stylesheets/fonts/gutenberg1939-default.ily
+++ b/ly/stylesheets/fonts/gutenberg1939-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Gutenberg1939 font.
+%}
+

--- a/ly/stylesheets/fonts/haydn-default.ily
+++ b/ly/stylesheets/fonts/haydn-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Haydn font.
+%}
+

--- a/ly/stylesheets/fonts/improviso-default.ily
+++ b/ly/stylesheets/fonts/improviso-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Improviso font.
+%}
+

--- a/ly/stylesheets/fonts/lilyboulez-default.ily
+++ b/ly/stylesheets/fonts/lilyboulez-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the LilyBoulez font.
+%}
+

--- a/ly/stylesheets/fonts/lilyjazz-default.ily
+++ b/ly/stylesheets/fonts/lilyjazz-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the LilyJAZZ font.
+%}
+

--- a/ly/stylesheets/fonts/paganini-default.ily
+++ b/ly/stylesheets/fonts/paganini-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Paganini font.
+%}
+

--- a/ly/stylesheets/fonts/profondo-default.ily
+++ b/ly/stylesheets/fonts/profondo-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Profondo font.
+%}
+

--- a/ly/stylesheets/fonts/ross-default.ily
+++ b/ly/stylesheets/fonts/ross-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Ross font.
+%}
+

--- a/ly/stylesheets/fonts/scorlatti-default.ily
+++ b/ly/stylesheets/fonts/scorlatti-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Scorlatti font.
+%}
+

--- a/ly/stylesheets/fonts/sebastiano-default.ily
+++ b/ly/stylesheets/fonts/sebastiano-default.ily
@@ -1,0 +1,34 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of Stylesheets,                                           %
+%                      ===========                                            %
+% a library to manage and use style sheets and alternative fonts with         %
+% the GNU LilyPond engraving software,                                        %
+% belonging to openLilyLib (https://github.com/openlilylib/openlilylib        %
+%              -----------                                                    %
+%                                                                             %
+% Stylesheets is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% Stylesheets is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU Lesser General Public License for more details.                         %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with Stylesheets.  If not, see <http://www.gnu.org/licenses/>.        %
+%                                                                             %
+% Stylesheets is maintained by                                                %
+% - Urs Liska, ul@openlilylib.org                                             %
+% - Kieren MacMillan, kieren_macmillan@sympatico.ca                           %
+% - Abraham Lee, tisimst.lilypond@gmail.com                                   %
+% Copyright Urs Liska / Kieren MacMillan, Abraham Lee, 2015                   %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%{
+  Default stylesheet for the Sebastiano font.
+%}
+

--- a/ly/stylesheets/load-font
+++ b/ly/stylesheets/load-font
@@ -29,13 +29,22 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %{
-  Initialization of the Stylesheets library
+  Activate a font that is configured using \useNotationFont.
+  Do not include this file directly, as it is called implicitly through
+  the function. (This is why the file doesn't have an extension.)
+
+  TODO:
+  We are still looking for a way to avoid having to do this separate include.
+  The problem is that inside the function we don't have access to the
+  staff-height and pt variables
+  => Ideas and solutions welcome!
 %}
 
-% internal options for use in the font loading mechanism
-\registerOption stylesheets.font.name Emmentaler
-\registerOption stylesheets.font.use-name Emmentaler
-\registerOption stylesheets.font.brace Emmentaler
-\registerOption stylesheets.font.use-brace Emmentaler
+\paper {
+  #(define fonts
+    (set-global-fonts
+     #:music #{ \getOption stylesheets.font.use-name #}
+     #:brace #{ \getOption stylesheets.font.use-brace #}
+     #:factor (/ staff-height pt 20)))
+}
 
-#(oll:log "Initialized Stylesheets~a" "")


### PR DESCRIPTION
New library with initial implementation to using fonts.
Currently only the "Arnold" and "Gutenberg" fonts are supported.

See README file (https://github.com/openlilylib/openlilylib/blob/stylesheets/ly/stylesheets/README.md) for a description of the interface.
