### PR TITLE
gridly: Simplify public function interface

### DIFF
--- a/ly/gridly/CHANGELOG.md
+++ b/ly/gridly/CHANGELOG.md
@@ -3,6 +3,12 @@ GridLY - Changelog
 
  * 0.6.0 - **development**
 
+   This is a **breaking** release. The public interface changed
+
+   - Change the interface for `gridPutMusic` and `gridSetStructure`.
+     Now the function both accept three arguments, the last of which is
+     either a context modifier or music. See the discussion in Issue #104.
+
  * 0.5.0
 
    - Add bar number handling. See issue #101

--- a/ly/gridly/usage-examples/example.ly
+++ b/ly/gridly/usage-examples/example.ly
@@ -76,37 +76,36 @@
 \with {
   lyrics = \lyricmode { Fa }
   barNumber = 1
-}
-{
-  s1 |
+  music = {
+    s1 |
+  }
 }
 
 \gridSetSegmentTemplate 2
 \with {
   lyrics = \lyricmode { la la la! }
   barNumber = 2
-}
-{
-  s1 | s1 |
+  music = {
+    s1 | s1 |
+  }
 }
 
 \gridSetSegmentTemplate 3
 \with {
   barNumber = 4
-}
-{
-  s1 | s1 |
+  music = {
+    s1 | s1 |
+  }
 }
 
 
 \gridSetSegmentTemplate 4
 \with {
   barNumber = 6
+  music = {
+    s1 | s1|
+  }
 }
-{
-  s1 | s1|
-}
-
 
 %%% Entering music
 %%% --------------
@@ -119,17 +118,17 @@
 \gridPutMusic "soprano" 1
 \with {
   lyrics = \lyricmode { Fa la }
-}
-\relative c' {
-  e2 f |
+  music = \relative c' {
+    e2 f |
+  }
 }
 
 \gridPutMusic "soprano" 2
 \with {
   lyrics = \lyricmode { li le lo lu la! }
-}
-\relative c' {
-  f4 a g b | c1 |
+  music = \relative c' {
+    f4 a g b | c1 |
+  }
 }
 
 %%% The context modifier is optional: if you skip it, defaults for
@@ -182,9 +181,9 @@
 \gridPutMusic "soprano" 4
 \with {
   lyrics = \lyricmode {li le!}
-}
-\relative c'' {
-  g1 | c |
+  music = \relative c'' {
+    g1 | c |
+  }
 }
 
 %%% Compiling single cells

--- a/ly/gridly/usage-examples/multi-file/global.ily
+++ b/ly/gridly/usage-examples/multi-file/global.ily
@@ -8,7 +8,7 @@
 \gridSetSegmentTemplate #1
 \with {
   lyrics = \lyricmode { Ooo }
-}
-\relative c {
-  s1 |
+  music = \relative c {
+    s1 |
+  }
 }

--- a/ly/gridly/usage-examples/multi-file/parts/alto-I.ily
+++ b/ly/gridly/usage-examples/multi-file/parts/alto-I.ily
@@ -2,9 +2,9 @@
 
 \include "../global.ily"
 
-\gridPutMusic "alto" #1
+\gridPutMusic "alto" 1
 \relative c' {
   e1 |
 }
 
-\gridCompileCell "alto" #1
+\gridCompileCell "alto" 1

--- a/ly/gridly/usage-examples/multi-file/parts/basso-I.ily
+++ b/ly/gridly/usage-examples/multi-file/parts/basso-I.ily
@@ -2,13 +2,13 @@
 
 \include "../global.ily"
 
-\gridPutMusic "basso" #1
+\gridPutMusic "basso" 1
 \relative c {
   \clef "bass"
   c1 |
   \bar "|."
 }
 
-\gridCompileCell "basso" #1
+\gridCompileCell "basso" 1
 
 

--- a/ly/gridly/usage-examples/multi-file/parts/soprano-I.ily
+++ b/ly/gridly/usage-examples/multi-file/parts/soprano-I.ily
@@ -2,9 +2,9 @@
 
 \include "../global.ily"
 
-\gridPutMusic "soprano" #1
+\gridPutMusic "soprano" 1
 \relative c'' {
   g1 |
 }
 
-\gridCompileCell "soprano" #1
+\gridCompileCell "soprano" 1

--- a/ly/gridly/usage-examples/multi-file/parts/tenore-I.ily
+++ b/ly/gridly/usage-examples/multi-file/parts/tenore-I.ily
@@ -2,10 +2,10 @@
 
 \include "../global.ily"
 
-\gridPutMusic "tenore" #1
+\gridPutMusic "tenore" 1
 \relative c' {
   \clef "violin_8"
   c1 |
 }
 
-\gridCompileCell "tenore" #1
+\gridCompileCell "tenore" 1

--- a/ly/gridly/usage-examples/transpose.ly
+++ b/ly/gridly/usage-examples/transpose.ly
@@ -23,30 +23,30 @@
 \gridPutMusic "clarinet" 1
 \with {
   transposeKey = a,
-}
-\relative c' {
-  \key c \major
-  c d e f |
+  music = \relative c' {
+    \key c \major
+    c d e f |
+  }
 }
 
 %%% Different cells can have different transposition keys
 \gridPutMusic "clarinet" 2
 \with {
-  transposeKey = c
-}
-\relative c' {
-  \key c \major
-  c d e f |
+  transposeKey = c,
+  music = \relative c' {
+    \key c \major
+    c d e f |
+  }
 }
 
 
 \gridPutMusic "clarinet" 3
 \with {
   transposeKey = a,
-}
-\relative c' {
-  \key c \major
-  c d e f |
+  music = \relative c' {
+    \key c \major
+    c d e f |
+  }
 }
 
 


### PR DESCRIPTION
This commit changes the public interface of two functions in GridLY
public interface, namely `gridPutMusic` and `gridSetSegmentTemplate`.
Both these functions took a mandatory music argument, optionally
preceded by a context modifier to provide additional arguments. As per
the discussion in issue #104, this is somewhat confusing in the case of
cells using many optional arguments, since it is not immediately clear
that the music belongs to the cells.

To simplify this situation, the music argument is "pulled" inside the
context modifier, so the parentheses of the `with` block explicitly mark
the boundaries of the cell definition.

This is a breaking change. In order to ease the migration, two functions
are provided, namely `gridPutMusicDepr` and `gridSetSegmentTemplateDepr`
that use the old interface. Please refer to the "Migration guide" in
GridLY's README for more information.
