### PR TITLE
test: Exclude Arnold test

### DIFF
--- a/ly/stylesheets/usage-examples/.automated-tests-exclude
+++ b/ly/stylesheets/usage-examples/.automated-tests-exclude
@@ -1,0 +1,1 @@
+arnold--berg-opus-5-excerpt.ly


### PR DESCRIPTION
As the Arnold font _still_ isnt' released the breaking test
should not be part of the test suite.

Fixes #119 
