### PR TITLE
Refactor the tree data structure

### DIFF
--- a/ly/_internal/utilities/tree-example.ly
+++ b/ly/_internal/utilities/tree-example.ly
@@ -1,0 +1,101 @@
+\version "2.18.2"
+
+\include "tree.ily"
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Scheme example
+%%
+
+#(begin
+	 (display "Scheme example\n==============\n\n")
+	 
+	 (format #t "0. Create an empty tree\n")
+	 (define t (make-tree))
+	 (format #t "\n~a\n" t)
+
+	 (format #t "1. Add some content\n")
+
+	 (tree-set! t '("a" "b" "c") 10)
+	 (tree-set! t '("a" "b") 5)
+	 (tree-set! t '("a" "d" "ce") 14)
+
+	 (format #t "\n~a\n" t)
+
+	 (format #t "2. Get value for key '(a b c)\n\n~a\n\n"
+					 (tree-get t '("a" "b" "c")))
+
+	 (format #t "3. Get value for non-existing key with default '(a b d)\n\n~a\n\n"
+					 (tree-get t '("a" "b" "d") "default value"))
+
+	 (format #t "4. Get node for key '(a b c)\n\n")
+
+	 (define n (tree-get-node t '("a" "b" "c")))
+	 (format #t "node is ~a, value is ~a\n\n"
+					 n (node-value n))
+
+	 (format #t "5. Remove subtree rooted at '(a d)\n")
+	 (tree-remove! t '("a" "d"))
+	 (format #t "\n~a\n" t)
+
+	 (format #t "6. Try to access a non-existing key, without default\n\n")
+	 (catch 'key-error
+					(lambda ()
+						(tree-get t '("a" "d")))
+					(lambda (key . args)
+						(format #t "Caught exception ~a: ~a\n\n"
+										key (car args))))
+
+	 (format #t "7. Try to access an internal node that has no value\n\n")
+
+	 (catch 'missing-value
+					(lambda ()
+						(format #t "The value is ~a\n\n"
+										(tree-get t '("a"))))
+					(lambda (key . args)
+						(format #t "Caught exception ~a: ~a\n\n"
+										key (car args))))
+
+	 (format #t "8. Use the tree-lookup function for existing key\n\n")
+
+	 (tree-lookup t '("a" "b" "c")
+								(lambda (value)
+									(format #t "Found value: ~a\n\n" value))
+								(lambda (missing)
+									(format #t "Key ~a not found, do something\n\n" missing)))
+
+	 (format #t "9. Use the tree-lookup function for non existing key\n\n")
+
+	 (tree-lookup t '("non existent key")
+								(lambda (value)
+									(format #t "Found value: ~a\n\n" value))
+								(lambda (missing)
+									(format #t "Key ~a not found, do something\n\n" missing)))
+
+	 (format #t "10. Clear the tree\n")
+	 (tree-clear! t)
+	 (format #t "\n~a\n" t))
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Lilypond example
+%%
+
+#(display "Lilypond example\n================\n\n")
+
+\makeTree test
+
+\treeSet test #'(a b c) "test value"
+
+\treeGet test #'(a b c) "default value"
+\treeGetStrict test #'(a b c)
+
+#(display test)
+
+\treeRemove test #'(a b)
+
+#(format #t "~a\n\n" test)
+
+%% If you uncomment this, you will get an error message because you
+%% are looking for a non-existing path
+
+%\treeGetStrict test #'(a b d)

--- a/ly/_internal/utilities/tree-example.ly
+++ b/ly/_internal/utilities/tree-example.ly
@@ -7,73 +7,73 @@
 %%
 
 #(begin
-	 (display "Scheme example\n==============\n\n")
-	 
-	 (format #t "0. Create an empty tree\n")
-	 (define t (make-tree))
-	 (format #t "\n~a\n" t)
+   (display "Scheme example\n==============\n\n")
 
-	 (format #t "1. Add some content\n")
+   (format #t "0. Create an empty tree\n")
+   (define t (make-tree))
+   (format #t "\n~a\n" t)
 
-	 (tree-set! t '("a" "b" "c") 10)
-	 (tree-set! t '("a" "b") 5)
-	 (tree-set! t '("a" "d" "ce") 14)
+   (format #t "1. Add some content\n")
 
-	 (format #t "\n~a\n" t)
+   (tree-set! t '("a" "b" "c") 10)
+   (tree-set! t '("a" "b") 5)
+   (tree-set! t '("a" "d" "ce") 14)
 
-	 (format #t "2. Get value for key '(a b c)\n\n~a\n\n"
-					 (tree-get t '("a" "b" "c")))
+   (format #t "\n~a\n" t)
 
-	 (format #t "3. Get value for non-existing key with default '(a b d)\n\n~a\n\n"
-					 (tree-get t '("a" "b" "d") "default value"))
+   (format #t "2. Get value for key '(a b c)\n\n~a\n\n"
+           (tree-get t '("a" "b" "c")))
 
-	 (format #t "4. Get node for key '(a b c)\n\n")
+   (format #t "3. Get value for non-existing key with default '(a b d)\n\n~a\n\n"
+           (tree-get t '("a" "b" "d") "default value"))
 
-	 (define n (tree-get-node t '("a" "b" "c")))
-	 (format #t "node is ~a, value is ~a\n\n"
-					 n (node-value n))
+   (format #t "4. Get node for key '(a b c)\n\n")
 
-	 (format #t "5. Remove subtree rooted at '(a d)\n")
-	 (tree-remove! t '("a" "d"))
-	 (format #t "\n~a\n" t)
+   (define n (tree-get-node t '("a" "b" "c")))
+   (format #t "node is ~a, value is ~a\n\n"
+           n (node-value n))
 
-	 (format #t "6. Try to access a non-existing key, without default\n\n")
-	 (catch 'key-error
-					(lambda ()
-						(tree-get t '("a" "d")))
-					(lambda (key . args)
-						(format #t "Caught exception ~a: ~a\n\n"
-										key (car args))))
+   (format #t "5. Remove subtree rooted at '(a d)\n")
+   (tree-remove! t '("a" "d"))
+   (format #t "\n~a\n" t)
 
-	 (format #t "7. Try to access an internal node that has no value\n\n")
+   (format #t "6. Try to access a non-existing key, without default\n\n")
+   (catch 'key-error
+          (lambda ()
+            (tree-get t '("a" "d")))
+          (lambda (key . args)
+            (format #t "Caught exception ~a: ~a\n\n"
+                    key (car args))))
 
-	 (catch 'missing-value
-					(lambda ()
-						(format #t "The value is ~a\n\n"
-										(tree-get t '("a"))))
-					(lambda (key . args)
-						(format #t "Caught exception ~a: ~a\n\n"
-										key (car args))))
+   (format #t "7. Try to access an internal node that has no value\n\n")
 
-	 (format #t "8. Use the tree-lookup function for existing key\n\n")
+   (catch 'missing-value
+          (lambda ()
+            (format #t "The value is ~a\n\n"
+                    (tree-get t '("a"))))
+          (lambda (key . args)
+            (format #t "Caught exception ~a: ~a\n\n"
+                    key (car args))))
 
-	 (tree-lookup t '("a" "b" "c")
-								(lambda (value)
-									(format #t "Found value: ~a\n\n" value))
-								(lambda (missing)
-									(format #t "Key ~a not found, do something\n\n" missing)))
+   (format #t "8. Use the tree-lookup function for existing key\n\n")
 
-	 (format #t "9. Use the tree-lookup function for non existing key\n\n")
+   (tree-lookup t '("a" "b" "c")
+                (lambda (value)
+                  (format #t "Found value: ~a\n\n" value))
+                (lambda (missing)
+                  (format #t "Key ~a not found, do something\n\n" missing)))
 
-	 (tree-lookup t '("non existent key")
-								(lambda (value)
-									(format #t "Found value: ~a\n\n" value))
-								(lambda (missing)
-									(format #t "Key ~a not found, do something\n\n" missing)))
+   (format #t "9. Use the tree-lookup function for non existing key\n\n")
 
-	 (format #t "10. Clear the tree\n")
-	 (tree-clear! t)
-	 (format #t "\n~a\n" t))
+   (tree-lookup t '("non existent key")
+                (lambda (value)
+                  (format #t "Found value: ~a\n\n" value))
+                (lambda (missing)
+                  (format #t "Key ~a not found, do something\n\n" missing)))
+
+   (format #t "10. Clear the tree\n")
+   (tree-clear! t)
+   (format #t "\n~a\n" t))
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/ly/_internal/utilities/tree.ily
+++ b/ly/_internal/utilities/tree.ily
@@ -6,19 +6,19 @@
 #(use-modules (ice-9 format))
 
 #(define (parser-lookup-symbol parser symbol)
-	 (if (lilypond-greater-than? "2.19.21")
-			 (ly:parser-lookup symbol)
-			 (ly:parser-lookup parser symbol)))
+   (if (lilypond-greater-than? "2.19.21")
+       (ly:parser-lookup symbol)
+       (ly:parser-lookup parser symbol)))
 
 %{!
 % Create a new tree at the given symbol
 %}
 makeTree=
 #(define-void-function
-	 (parser location name) (symbol?)
-	 (if (lilypond-greater-than? "2.19.21")
-			 (ly:parser-define! name (make-tree))
-			 (ly:parser-define! parser name (make-tree))))
+   (parser location name) (symbol?)
+   (if (lilypond-greater-than? "2.19.21")
+       (ly:parser-define! name (make-tree))
+       (ly:parser-define! parser name (make-tree))))
 
 %{!
 % Set the value at the specified path. If the path already exists,
@@ -26,8 +26,8 @@ makeTree=
 %}
 treeSet=
 #(define-void-function
-	 (parser location name path value) (symbol? list? scheme?)
-	 (tree-set! (parser-lookup-symbol parser name) path value))
+   (parser location name path value) (symbol? list? scheme?)
+   (tree-set! (parser-lookup-symbol parser name) path value))
 
 %{!
 % Get the value at the specified path. If the path exists, return
@@ -35,8 +35,8 @@ treeSet=
 %}
 treeGet=
 #(define-scheme-function
-	 (parser location name path default) (symbol? list? scheme?)
-	 (tree-get (parser-lookup-symbol parser name) path default))
+   (parser location name path default) (symbol? list? scheme?)
+   (tree-get (parser-lookup-symbol parser name) path default))
 
 %{!
 % Get the value at the specified path. If the path exists, return
@@ -44,12 +44,12 @@ treeGet=
 %}
 treeGetStrict=
 #(define-scheme-function
-	 (parser location name path) (symbol? list?)
-	 (catch 'key-error
-					(lambda ()
-						(tree-get (parser-lookup-symbol parser name) path))
-					(lambda (key . args)
-						(ly:error "~a: ~a" key (car args)))))
+   (parser location name path) (symbol? list?)
+   (catch 'key-error
+          (lambda ()
+            (tree-get (parser-lookup-symbol parser name) path))
+          (lambda (key . args)
+            (ly:error "~a: ~a" key (car args)))))
 
 %{!
 % Remove the value at the specified path. If the path does not exist,
@@ -57,5 +57,5 @@ treeGetStrict=
 %}
 treeRemove=
 #(define-void-function
-	 (parser location name path) (symbol? list?)
-	 (tree-remove! (parser-lookup-symbol parser name) path))
+   (parser location name path) (symbol? list?)
+   (tree-remove! (parser-lookup-symbol parser name) path))

--- a/ly/_internal/utilities/tree.ily
+++ b/ly/_internal/utilities/tree.ily
@@ -1,0 +1,61 @@
+\version "2.18.2"
+
+\include "openlilylib"
+
+#(use-modules (_internal utilities tree))
+#(use-modules (ice-9 format))
+
+#(define (parser-lookup-symbol parser symbol)
+	 (if (lilypond-greater-than? "2.19.21")
+			 (ly:parser-lookup symbol)
+			 (ly:parser-lookup parser symbol)))
+
+%{!
+% Create a new tree at the given symbol
+%}
+makeTree=
+#(define-void-function
+	 (parser location name) (symbol?)
+	 (if (lilypond-greater-than? "2.19.21")
+			 (ly:parser-define! name (make-tree))
+			 (ly:parser-define! parser name (make-tree))))
+
+%{!
+% Set the value at the specified path. If the path already exists,
+% update the old value
+%}
+treeSet=
+#(define-void-function
+	 (parser location name path value) (symbol? list? scheme?)
+	 (tree-set! (parser-lookup-symbol parser name) path value))
+
+%{!
+% Get the value at the specified path. If the path exists, return
+% the associated value, otherwise return the given default value.
+%}
+treeGet=
+#(define-scheme-function
+	 (parser location name path default) (symbol? list? scheme?)
+	 (tree-get (parser-lookup-symbol parser name) path default))
+
+%{!
+% Get the value at the specified path. If the path exists, return
+% the associated value, otherwise terminate with an error.
+%}
+treeGetStrict=
+#(define-scheme-function
+	 (parser location name path) (symbol? list?)
+	 (catch 'key-error
+					(lambda ()
+						(tree-get (parser-lookup-symbol parser name) path))
+					(lambda (key . args)
+						(ly:error "~a: ~a" key (car args)))))
+
+%{!
+% Remove the value at the specified path. If the path does not exist,
+% do nothing.
+%}
+treeRemove=
+#(define-void-function
+	 (parser location name path) (symbol? list?)
+	 (tree-remove! (parser-lookup-symbol parser name) path))

--- a/ly/_internal/utilities/tree.scm
+++ b/ly/_internal/utilities/tree.scm
@@ -62,13 +62,13 @@
 ;;    nodes, in case of success, as follows
 ;;
 ;;        (let ((node (tree-get-node tree path)))
-;;					(if node
-;;							(let ((value (node-value node)))
-;;								;; Do something with value
-;;								)
-;;							(begin
-;;								;; Do something to handle the missing value
-;;								)))        
+;;          (if node
+;;              (let ((value (node-value node)))
+;;                ;; Do something with value
+;;                )
+;;              (begin
+;;                ;; Do something to handle the missing value
+;;                )))
 ;;
 ;; 3. The function `tree-lookup'. This function makes the use case
 ;;    described in the last example simpler to use. You invoke it as
@@ -81,12 +81,12 @@
 ;;    path does not exists. So, for instance, you have
 ;;
 ;;        (tree-lookup tree path
-;;				  (lambda (value)
-;;						;; do something with value
-;;						)
-;;					(lambda (missing-path)
-;;						;; do something to handle the missing path
-;;						))
+;;           (lambda (value)
+;;             ;; do something with value
+;;             )
+;;           (lambda (missing-path)
+;;             ;; do something to handle the missing path
+;;             ))
 ;;
 ;; ### Clearing a tree
 ;;
@@ -121,16 +121,16 @@
 ;; contexts where such values are unavailable.
 ;;
 (define-module (_internal utilities tree)
-	#:export (make-tree
-						tree-set!
-						tree-remove!
-						tree-get
-						tree-get-node
-						node-value
-						tree-lookup
-						tree-clear!)
-	#:use-module ((oop goops)
-								(ice-9 format)))
+  #:export (make-tree
+            tree-set!
+            tree-remove!
+            tree-get
+            tree-get-node
+            node-value
+            tree-lookup
+            tree-clear!)
+  #:use-module ((oop goops)
+                (ice-9 format)))
 
 ;;
 ;; Node
@@ -157,66 +157,66 @@
 ;;  - children: a list of children of this node.
 ;;
 (define-class <node> ()
-	(name #:init-keyword #:name
-				#:getter name)
-	(has-value #:init-value #f
-						 #:init-keyword #:has-value
-						 #:accessor has-value)
-	(value #:init-value '()
-				 #:init-keyword #:value
-				 #:accessor value)
-	(children #:init-value '()
-						#:accessor children))
+  (name #:init-keyword #:name
+        #:getter name)
+  (has-value #:init-value #f
+             #:init-keyword #:has-value
+             #:accessor has-value)
+  (value #:init-value '()
+         #:init-keyword #:value
+         #:accessor value)
+  (children #:init-value '()
+            #:accessor children))
 
 ;; Given a node, return its associated value. If the node has no
 ;; associated value (i.e. (= #f (has-value node))), then a
 ;; 'missing-value exception is thrown.
 (define-method (node-value (n <node>))
-	(if (has-value n)
-			(value n)
-			(throw 'missing-value
-						 "The node exists, but has no associated value")))
+  (if (has-value n)
+      (value n)
+      (throw 'missing-value
+             "The node exists, but has no associated value")))
 
 ;; Adds a single child to the given node
 (define-method (add-child (n <node>) (c <node>))
-	(let ((new-children (cons c (children n))))
-		(set! (children n) new-children)
-		n))
+  (let ((new-children (cons c (children n))))
+    (set! (children n) new-children)
+    n))
 
 ;; Adds a list of children to the given node
 (define-method (add-children (n <node>) children)
-	(if (null? children)
-			n
-			(let ((new-node (add-child n (car children))))
-				(add-children new-node (cdr children)))))
+  (if (null? children)
+      n
+      (let ((new-node (add-child n (car children))))
+        (add-children new-node (cdr children)))))
 
 ;; Removes a single child by name. If the child does not exist, then
 ;; this function does nothing.
 (define-method (remove-child (n <node>) child-name)
-	(let ((new-children (filter (lambda (child)
-																(not (equal? (name child) child-name)))
-											 (children n))))
-		(set! (children n) new-children)
-		n))
+  (let ((new-children (filter (lambda (child)
+                                (not (equal? (name child) child-name)))
+                              (children n))))
+    (set! (children n) new-children)
+    n))
 
 ;; Gets a single child by name. If the child is not present, then
 ;; return #f. Note that there is no ambiguity when this function
 ;; returns #f. A node whose value is #f is a different entity with
 ;; respect to #f itself.
 (define-method (get-child (n <node>) child-name)
-	(let ((matching-children (filter (lambda (child)
-																		 (equal? (name child) child-name))
-																	 (children n))))
-		(if (null? matching-children)
-				#f
-				(car matching-children))))
+  (let ((matching-children (filter (lambda (child)
+                                     (equal? (name child) child-name))
+                                   (children n))))
+    (if (null? matching-children)
+        #f
+        (car matching-children))))
 
-;; Overrides the `display' function for nodes. 
+;; Overrides the `display' function for nodes.
 (define-method (display (n <node>) port)
-	(format port "<~a . ~a ~a>" (name n) (has-value n) (value n)))
+  (format port "<~a . ~a ~a>" (name n) (has-value n) (value n)))
 
 ;;
-;; Tree 
+;; Tree
 ;; ====
 ;;
 ;; A tree is simply an object with a root node. This root node is
@@ -224,8 +224,8 @@
 ;; child.
 ;;
 (define-class <tree> ()
-	(root #:init-form (make <node> #:name "root")
-				#:accessor root))
+  (root #:init-form (make <node> #:name "root")
+        #:accessor root))
 
 ;; Create a new empty tree
 (define (make-tree) (make <tree>))
@@ -233,99 +233,99 @@
 ;; Utility method. Associates the given value to the given path, as a
 ;; subtree of node `n'.
 (define-method (subtree-set! (n <node>) path val)
-	(cond
-	 ((null? path) (error "Path in a tree cannot be empty"))
-	 ((null? (cdr path)) (let ((child (get-child n (car path))))
-												 (if child
-														 (begin
-															 (set! (value child) val)
-															 (set! (has-value child) #t))
-														 (let ((c (make <node>
-																				#:name (car path)
-																				#:value val
-																				#:has-value #t)))
-															 (add-child n c)))))
-	 (else (let ((child (get-child n (car path))))
-					 (if child
-							 (subtree-set! child (cdr path) val)
-							 (let ((c (make <node> #:name (car path))))
-								 (add-child n c)
-								 (subtree-set! c (cdr path) val)))))))
+  (cond
+   ((null? path) (error "Path in a tree cannot be empty"))
+   ((null? (cdr path)) (let ((child (get-child n (car path))))
+                         (if child
+                             (begin
+                               (set! (value child) val)
+                               (set! (has-value child) #t))
+                             (let ((c (make <node>
+                                        #:name (car path)
+                                        #:value val
+                                        #:has-value #t)))
+                               (add-child n c)))))
+   (else (let ((child (get-child n (car path))))
+           (if child
+               (subtree-set! child (cdr path) val)
+               (let ((c (make <node> #:name (car path))))
+                 (add-child n c)
+                 (subtree-set! c (cdr path) val)))))))
 
 ;; Associate the given value to the given path. If the path already
 ;; exists, then the value is update, otherwise any missing node is
 ;; created.
 (define-method (tree-set! (t <tree>) path val)
-	(subtree-set! (root t) path val))
+  (subtree-set! (root t) path val))
 
 ;; Utility function. Retrieves the node associated with `path',
 ;; starting from the given node.
 (define-method (subtree-get-node (n <node>) path)
-	(cond
-	 ((null? path) (error "Path in a tree cannot be empty"))
-	 ((null? (cdr path)) (get-child n (car path)))
-	 (else (let ((c (get-child n (car path))))
-					 (if c
-							 (subtree-get-node c (cdr path))
-							 #f)))))
+  (cond
+   ((null? path) (error "Path in a tree cannot be empty"))
+   ((null? (cdr path)) (get-child n (car path)))
+   (else (let ((c (get-child n (car path))))
+           (if c
+               (subtree-get-node c (cdr path))
+               #f)))))
 
 ;; Retrieves the node associated with `path'. If `path' does not
 ;; exist, then return #f
 (define-method (tree-get-node (t <tree>) path)
-	(subtree-get-node (root t) path))
+  (subtree-get-node (root t) path))
 
 ;; Look up `path' in tree `t'. If the path exists, return its
 ;; associated value. Otherwise, if a `default-value' is give return
 ;; it, else throw a 'key-error exception.
 (define (tree-get t path . default-value)
-	(let ((n (tree-get-node t path)))
-		(cond
-		 (n (node-value n))
-		 ((not (null? default-value)) (car default-value))
-		 (else (throw 'key-error
-									(format #f "Path ~a not present in tree" path))))))
+  (let ((n (tree-get-node t path)))
+    (cond
+     (n (node-value n))
+     ((not (null? default-value)) (car default-value))
+     (else (throw 'key-error
+                  (format #f "Path ~a not present in tree" path))))))
 
 ;; Lookup a path in the tree. If the path exists, then invoke
 ;; success-fn with the value as argument, otherwise invoke failure-fn
 ;; with the path as argument.
 (define-method (tree-lookup (t <tree>) path success-fn failure-fn)
-	(let ((node (tree-get-node t path)))
-		(if node
-				(success-fn (node-value node))
-				(failure-fn path))))
+  (let ((node (tree-get-node t path)))
+    (if node
+        (success-fn (node-value node))
+        (failure-fn path))))
 
 ;; Utility function. Remove a path starting from the given node. If
 ;; the path dows not exist, then do nothing. Note that if the path
 ;; does not end at a leaf node, then an entire subtree is removed.
 (define-method (subtree-remove! (n <node>) path)
-	(cond
-	 ((null? path) (error "Path in a tree cannot be empty"))
-	 ((null? (cdr path)) (remove-child n (car path)))
-	 (else (let ((c (get-child n (car path))))
-					 (if c
-							 (subtree-remove! c (cdr path))
-							 #f)))))
+  (cond
+   ((null? path) (error "Path in a tree cannot be empty"))
+   ((null? (cdr path)) (remove-child n (car path)))
+   (else (let ((c (get-child n (car path))))
+           (if c
+               (subtree-remove! c (cdr path))
+               #f)))))
 
 ;; Remove a path from the tree. If the path does not exist, then
 ;; nothing happens. Note that if the path does not end at a leaf node,
 ;; then an entire subtree is removed.
 (define-method (tree-remove! (t <tree>) path)
-	(subtree-remove! (root t) path))
+  (subtree-remove! (root t) path))
 
 ;; Remove all the nodes from the tree.
 (define-method (tree-clear! (t <tree>))
-	(set! (children (root t)) '()))
+  (set! (children (root t)) '()))
 
 ;; Utility function: recursively display a subtree.
 (define (rec-display port n indent)
-	(format port "~a~a\n" indent n)
-	(for-each
-	 (lambda (c)
-		 (rec-display port c (string-append indent "    ")))
-	 (children n)))
+  (format port "~a~a\n" indent n)
+  (for-each
+   (lambda (c)
+     (rec-display port c (string-append indent "    ")))
+   (children n)))
 
 ;; Overrides `display' for tree. Pretty prints the tree on the given
 ;; port.
 (define-method (display (t <tree>) port)
-	(rec-display port (root t) "")
-	(newline port))
+  (rec-display port (root t) "")
+  (newline port))

--- a/ly/_internal/utilities/tree.scm
+++ b/ly/_internal/utilities/tree.scm
@@ -1,0 +1,331 @@
+;; Tree module
+;; ===========
+;;
+;; This module implements a tree data structure that allows to
+;; associate values with paths. Values can be arbitrary scheme
+;; entities, whereas paths are represented as lists.
+;;
+;; Public API overview
+;; -------------------
+;;
+;; First of all, a word on the naming convention adopted. All the
+;; public functions that modify the tree have their name followed by
+;; an exclamation mark (for instance tree-set! and
+;; tree-remove!). Functions whose name is not followed by an
+;; exclamation mark do not modify the tree (like all lookup functions,
+;; e.g. tree-get and tree-lookup).
+;;
+;; ### Tree creation
+;;
+;; To create a new tree, use the function (make-tree).
+;;
+;; ### Insertion of values
+;;
+;; Once you have a tree object, you can start to associate values to
+;; paths witht the function
+;;
+;;     (tree-set! tree path value)
+;;
+;; ### Removal of subtrees
+;;
+;; You can remove entire subtrees (and all their associated values)
+;; with the function
+;;
+;;     (tree-remove! tree path)
+;;
+;; that, if the specified path does not exists in the tree, simply
+;; does nothing.
+;;
+;; ### Retrieval of values
+;;
+;; To retrieve values from the tree, you have several options
+;;
+;; 1. The function `tree-get'. You can use this function as follows
+;;
+;;        (tree-get tree path default)
+;;
+;;    If the requested path is in the tree, the associated value is
+;;    returned, otherwise the function returns the default value,
+;;    which is an optional argument. If the default value is not
+;;    specified and the requested path does not exist in the tree,
+;;    then a 'key-error exception is thrown. See
+;;    https://www.gnu.org/software/guile/docs/docs-1.8/guile-ref/Catch.html
+;;    for information on how to handle exceptions.
+;;
+;; 2. The function `tree-get-node', that is used as
+;;
+;;        (tree-get-node tree path)
+;;
+;;    This function returns the node associated with the given path if
+;;    it exists, and #f otherwise. You can use it in combination with
+;;    the `node-value' function to extract the value stored in the
+;;    nodes, in case of success, as follows
+;;
+;;        (let ((node (tree-get-node tree path)))
+;;					(if node
+;;							(let ((value (node-value node)))
+;;								;; Do something with value
+;;								)
+;;							(begin
+;;								;; Do something to handle the missing value
+;;								)))        
+;;
+;; 3. The function `tree-lookup'. This function makes the use case
+;;    described in the last example simpler to use. You invoke it as
+;;    follows
+;;
+;;        (tree-lookup tree path success-fn failure-fn)
+;;
+;;    where `success-fn' is a function to call if the path exists in
+;;    the tree, and `failure-fn' is a function to call in case the
+;;    path does not exists. So, for instance, you have
+;;
+;;        (tree-lookup tree path
+;;				  (lambda (value)
+;;						;; do something with value
+;;						)
+;;					(lambda (missing-path)
+;;						;; do something to handle the missing path
+;;						))
+;;
+;; ### Clearing a tree
+;;
+;; If you need to reset a given tree to its empy state, just call
+;;
+;;     (tree-clear! tree)
+;;
+;; Rationale
+;; ---------
+;;
+;; This scheme module is heavily based on the the `alist-access.ily'
+;; module by Jan-Peter Voigt. It tries to address some concerns with
+;; the previous approach (see, for instance,
+;; https://github.com/openlilylib/openlilylib/issues/68), namely
+;;
+;; 1. The function to get values from the tree has a not well defined
+;;    behaviour for missing values: in case of missing values it will
+;;    return #f, however #f is also a legitimate value, hence we
+;;    cannot distinguish in wuich case we are into.
+;;
+;; 2. All the tree-related functions accept a parser and a location as
+;;    arguments. This means that they can be used only in contexts
+;;    where such values are in scope. This means that these values
+;;    need to be passed down the call stack, leading to code that is,
+;;    arguably, more cluttered.
+;;
+;; In order to address these issues, this module defines a
+;; well-specified public interface, where missing values are signaled
+;; without ambiguity (see the API averview above for a
+;; summary). Moreover, none of this module's functions relies on
+;; `parser' and `location' values, hence they are simpler to use in
+;; contexts where such values are unavailable.
+;;
+(define-module (_internal utilities tree)
+	#:export (make-tree
+						tree-set!
+						tree-remove!
+						tree-get
+						tree-get-node
+						node-value
+						tree-lookup
+						tree-clear!)
+	#:use-module ((oop goops)
+								(ice-9 format)))
+
+;;
+;; Node
+;; ====
+;;
+;; Node objects are private to this module. The only public function
+;; accessible from other modules is `node-value', that returns the
+;; value associated to a given node.
+;;
+;; NOTE: <node> and <tree> make use of the object-oriented features of
+;; Guile scheme. For more information on the topic, have a look to
+;; http://www.gnu.org/software/guile/manual/html_node/GOOPS.html
+;;
+;; A node is an object with four fields, namely
+;;
+;;  - name: is used to determine if a node is part of a path
+;;
+;;  - has-value: is used to establish if the value field contains a
+;;               valid value. This allows to distinguish between nodes
+;;               whose value is '() because they have no values from
+;;               nodes whose value is actually '().
+;;  - value: the value stored in the node. Note that even internal
+;;           nodes of the tree can contain a value.
+;;  - children: a list of children of this node.
+;;
+(define-class <node> ()
+	(name #:init-keyword #:name
+				#:getter name)
+	(has-value #:init-value #f
+						 #:init-keyword #:has-value
+						 #:accessor has-value)
+	(value #:init-value '()
+				 #:init-keyword #:value
+				 #:accessor value)
+	(children #:init-value '()
+						#:accessor children))
+
+;; Given a node, return its associated value. If the node has no
+;; associated value (i.e. (= #f (has-value node))), then a
+;; 'missing-value exception is thrown.
+(define-method (node-value (n <node>))
+	(if (has-value n)
+			(value n)
+			(throw 'missing-value
+						 "The node exists, but has no associated value")))
+
+;; Adds a single child to the given node
+(define-method (add-child (n <node>) (c <node>))
+	(let ((new-children (cons c (children n))))
+		(set! (children n) new-children)
+		n))
+
+;; Adds a list of children to the given node
+(define-method (add-children (n <node>) children)
+	(if (null? children)
+			n
+			(let ((new-node (add-child n (car children))))
+				(add-children new-node (cdr children)))))
+
+;; Removes a single child by name. If the child does not exist, then
+;; this function does nothing.
+(define-method (remove-child (n <node>) child-name)
+	(let ((new-children (filter (lambda (child)
+																(not (equal? (name child) child-name)))
+											 (children n))))
+		(set! (children n) new-children)
+		n))
+
+;; Gets a single child by name. If the child is not present, then
+;; return #f. Note that there is no ambiguity when this function
+;; returns #f. A node whose value is #f is a different entity with
+;; respect to #f itself.
+(define-method (get-child (n <node>) child-name)
+	(let ((matching-children (filter (lambda (child)
+																		 (equal? (name child) child-name))
+																	 (children n))))
+		(if (null? matching-children)
+				#f
+				(car matching-children))))
+
+;; Overrides the `display' function for nodes. 
+(define-method (display (n <node>) port)
+	(format port "<~a . ~a ~a>" (name n) (has-value n) (value n)))
+
+;;
+;; Tree 
+;; ====
+;;
+;; A tree is simply an object with a root node. This root node is
+;; names "root", has no value and initially it does not have any
+;; child.
+;;
+(define-class <tree> ()
+	(root #:init-form (make <node> #:name "root")
+				#:accessor root))
+
+;; Create a new empty tree
+(define (make-tree) (make <tree>))
+
+;; Utility method. Associates the given value to the given path, as a
+;; subtree of node `n'.
+(define-method (subtree-set! (n <node>) path val)
+	(cond
+	 ((null? path) (error "Path in a tree cannot be empty"))
+	 ((null? (cdr path)) (let ((child (get-child n (car path))))
+												 (if child
+														 (begin
+															 (set! (value child) val)
+															 (set! (has-value child) #t))
+														 (let ((c (make <node>
+																				#:name (car path)
+																				#:value val
+																				#:has-value #t)))
+															 (add-child n c)))))
+	 (else (let ((child (get-child n (car path))))
+					 (if child
+							 (subtree-set! child (cdr path) val)
+							 (let ((c (make <node> #:name (car path))))
+								 (add-child n c)
+								 (subtree-set! c (cdr path) val)))))))
+
+;; Associate the given value to the given path. If the path already
+;; exists, then the value is update, otherwise any missing node is
+;; created.
+(define-method (tree-set! (t <tree>) path val)
+	(subtree-set! (root t) path val))
+
+;; Utility function. Retrieves the node associated with `path',
+;; starting from the given node.
+(define-method (subtree-get-node (n <node>) path)
+	(cond
+	 ((null? path) (error "Path in a tree cannot be empty"))
+	 ((null? (cdr path)) (get-child n (car path)))
+	 (else (let ((c (get-child n (car path))))
+					 (if c
+							 (subtree-get-node c (cdr path))
+							 #f)))))
+
+;; Retrieves the node associated with `path'. If `path' does not
+;; exist, then return #f
+(define-method (tree-get-node (t <tree>) path)
+	(subtree-get-node (root t) path))
+
+;; Look up `path' in tree `t'. If the path exists, return its
+;; associated value. Otherwise, if a `default-value' is give return
+;; it, else throw a 'key-error exception.
+(define (tree-get t path . default-value)
+	(let ((n (tree-get-node t path)))
+		(cond
+		 (n (node-value n))
+		 ((not (null? default-value)) (car default-value))
+		 (else (throw 'key-error
+									(format #f "Path ~a not present in tree" path))))))
+
+;; Lookup a path in the tree. If the path exists, then invoke
+;; success-fn with the value as argument, otherwise invoke failure-fn
+;; with the path as argument.
+(define-method (tree-lookup (t <tree>) path success-fn failure-fn)
+	(let ((node (tree-get-node t path)))
+		(if node
+				(success-fn (node-value node))
+				(failure-fn path))))
+
+;; Utility function. Remove a path starting from the given node. If
+;; the path dows not exist, then do nothing. Note that if the path
+;; does not end at a leaf node, then an entire subtree is removed.
+(define-method (subtree-remove! (n <node>) path)
+	(cond
+	 ((null? path) (error "Path in a tree cannot be empty"))
+	 ((null? (cdr path)) (remove-child n (car path)))
+	 (else (let ((c (get-child n (car path))))
+					 (if c
+							 (subtree-remove! c (cdr path))
+							 #f)))))
+
+;; Remove a path from the tree. If the path does not exist, then
+;; nothing happens. Note that if the path does not end at a leaf node,
+;; then an entire subtree is removed.
+(define-method (tree-remove! (t <tree>) path)
+	(subtree-remove! (root t) path))
+
+;; Remove all the nodes from the tree.
+(define-method (tree-clear! (t <tree>))
+	(set! (children (root t)) '()))
+
+;; Utility function: recursively display a subtree.
+(define (rec-display port n indent)
+	(format port "~a~a\n" indent n)
+	(for-each
+	 (lambda (c)
+		 (rec-display port c (string-append indent "    ")))
+	 (children n)))
+
+;; Overrides `display' for tree. Pretty prints the tree on the given
+;; port.
+(define-method (display (t <tree>) port)
+	(rec-display port (root t) "")
+	(newline port))


### PR DESCRIPTION
This refactoring aims to solve a couple of issues of the current
implementation of alist-access.ily
1. The function to get values from the tree has a not well defined
   behaviour for missing values: in case of missing values it will
   return #f, however #f is also a legitimate value, hence we
   cannot distinguish in wuich case we are into. (see #68)
2. All the tree-related functions accept a parser and a location as
   arguments. This means that they can be used only in contexts
   where such values are in scope. This means that these values
   need to be passed down the call stack, leading to code that is,
   arguably, more cluttered.

The new tree module defines a well-specified public interface, where
missing values are signaled without ambiguity (see the API averview in
tree.scm above for a summary). Moreover, none of this module's functions
relies on `parser' and`location' values, hence they are simpler to use
in contexts where such values are unavailable.

I don't mean to sound rude towards @jpvoigt , I simply took the occasion
offered by #68 to refactor his work addressing also issue (2) of the above
list, which in my opinion simplifies the usage of the tree data structure :-)
