### PR TITLE
Tablature library: add the bending module

### DIFF
--- a/ly/tablature/README.md
+++ b/ly/tablature/README.md
@@ -19,6 +19,94 @@ As LilyPond supports microtones in tablature since
 [version 2.19.31](https://sourceforge.net/p/testlilyissues/issues/4643/),
 this module should be used only to compile files written for earlier versions.
 
-## Bending
+## String bending
 
-(to be added)
+LilyPond doesn't support guitar string bending yet.  This snippet
+contains a Scheme file which provides some basic features.  It was
+written by Marc Hohl in 2009.
+
+There are currently two open issues in the tracker:
+
+- [issue 3700](https://sourceforge.net/p/testlilyissues/issues/3700/)
+  aims at integrating the guitar bending written by Marc in Scheme
+  in the LilyPond codebase.
+- [issue 1196](https://sourceforge.net/p/testlilyissues/issues/1196/)
+  is about adding a new bend engraver, which is the ultimate goal.
+
+
+### Limitations
+
+- Quarter tone bends are not supported.
+- Line breaks over bending notes are not supported and they are currently
+  disabled, because otherwise the file would not compile as soon as page
+  formatting decisions create such a situation.
+- You can't use hammer-on and pull-off when `\bendOn` is active, because
+  this snippet uses and transforms the slur engraver.  This implies that
+  you cannot, for instance, start a pull-off right after a bend release.
+  This is one of the reasons why a bend engraver is needed (see
+  issue 1196 above). However, you can work around this problem by adding
+  an hidden grace note  where the pull-off should start; you may have to
+  use the `\shape` command to adjust the slur shape.
+- If you use Staff and TabStaff, you may have to add some more padding
+  in order to avoid collisions between the bending interval number and
+  the staff:
+  ```
+  \layout {
+    \context {
+      \StaffGroup
+      \override StaffGrouper.staff-staff-spacing.padding = #5
+    }
+  }
+  ```
+
+
+### Usage
+
+Add this repository to the list of include paths in your editor preferences
+and put the following include statement at the top of your file:
+
+    \include "notation-snippets/guitar-string-bending/definitions.ily"
+
+You can activate and deactivate the bending with the following commands:
+
+    % music...
+    \bendOn
+    % bended notes here
+    \bendOff
+
+> Remember to put the music in Voice or TabVoice contexts (not just Staff
+> or TabStaff), otherwise you may get an extra staff, as explained in the
+> [Usage manual](http://lilypond.org/doc/stable/Documentation/usage/common-errors.html#an-extra-staff-appears).
+
+Within these commands, the parentheses, normally used to notate slurs,
+will notate the bendings.  You can write any bending from a half
+tone up to any interval (a number over the bending arrow will show
+the interval):
+
+    d8( dis)
+    d8( e)
+    d8( f)
+
+Bend and release requires the use of a closing parenthesis to close the
+bending and a new opening one to start the release:
+
+    d8( e)( d)
+
+Pre-bends - when string is bent before plucking it - are supported
+through the `\bendGrace` command and two different \preBend commands:
+
+    \bendGrace { \preBendHold c8( } d2)  r2
+    \bendGrace { \preBendRelease c8( d)( } c2)  r2
+
+`\preBendHold` is a simple pre-bend, while `\preBendRelease` allows to
+release the bending.
+
+Finally, there are two commands that control how a bending behaves
+along the time.  `\bendHold` allows to hold a bend for a longer time
+by using ties:
+
+    d8( \holdBend e) ~ e2( d)
+
+`\shiftBend` allows to bend a string in two steps:
+
+    c4( \shiftBend d)( e2)

--- a/ly/tablature/README.md
+++ b/ly/tablature/README.md
@@ -73,10 +73,11 @@ You can activate and deactivate the bending with the following commands:
 > [Usage manual](http://lilypond.org/doc/stable/Documentation/usage/common-errors.html#an-extra-staff-appears).
 
 Within these commands, the parentheses, normally used to notate slurs,
-will notate the bendings.  You can write any bending from a half
+will notate the bendings.  You can write any bending from a quarter
 tone up to any interval (a number over the bending arrow will show
 the interval):
 
+    d8( dih)
     d8( dis)
     d8( e)
     d8( f)

--- a/ly/tablature/README.md
+++ b/ly/tablature/README.md
@@ -36,7 +36,6 @@ There are currently two open issues in the tracker:
 
 ### Limitations
 
-- Quarter tone bends are not supported.
 - Line breaks over bending notes are not supported and they are currently
   disabled, because otherwise the file would not compile as soon as page
   formatting decisions create such a situation.
@@ -61,11 +60,6 @@ There are currently two open issues in the tracker:
 
 
 ### Usage
-
-Add this repository to the list of include paths in your editor preferences
-and put the following include statement at the top of your file:
-
-    \include "notation-snippets/guitar-string-bending/definitions.ily"
 
 You can activate and deactivate the bending with the following commands:
 

--- a/ly/tablature/__init__.ily
+++ b/ly/tablature/__init__.ily
@@ -35,5 +35,5 @@ currently supported upstream by LilyPond.  While some of these features
 might not be specific of tablatures or instruments like guitar, bass, etc.,
 the name Tablature seemed to be the best comprehensive term in most cases.
 It currently provides the following features: microtones in tablature;
-bending (to be added)."
+string bending."
 }

--- a/ly/tablature/bending.ily
+++ b/ly/tablature/bending.ily
@@ -1,0 +1,439 @@
+\version "2.16.2" % absolutely necessary!
+
+\header {
+  oll-title = "Guitar string bending notation"
+  oll-author = "Marc Hohl"
+  oll-description = \markup {
+    This snippet allows to typeset bend symbols -
+    typically used on guitar - on Staff and TabStaff.
+    While issue 1196 aims to create a specific engraver
+    for bends, this snippet leverages the slur engraver.
+  }
+}
+
+% TODO:
+% - draw dashed line for \holdBend
+% - enable consecutive bend ups
+% - simplify \preBend and \holdBend usage
+% - ...
+
+%%% sizes and values (to be changed/adapted):
+
+#(define bend-line-thickness 0.1)
+
+#(define bend-arrow-curvature-factor 0.35)
+
+#(define y-distance-from-tabstaff-to-arrow-tip 2.75)
+
+#(define consecutive-bends-arrow-height 2.75)
+
+#(define bend-arrowhead-height 1.25)
+
+#(define bend-arrowhead-width 0.8)
+
+#(define y-distance-from-staffline-to-arrow 0.35)
+
+%%% internal commands
+#(define (quarterdiff->string quarterdiff)
+   (let ((wholesteps (floor (/ quarterdiff 4))))
+
+     (string-append (case wholesteps
+                      ((0) "")
+                      (else (number->string wholesteps)))
+       (case (modulo quarterdiff 4)
+         ((1) "¼")
+         ((2) "½")
+         ((3) "¾")
+         (else "")))))
+
+%%% markup commands
+
+#(define-markup-command (pointedSlur layout props thickness bx by mx my ex ey)
+   (number? number? number? number? number? number? number?)
+   (interpret-markup layout props
+     (markup #:postscript
+       (ly:format "~f setlinewidth
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        ~f ~f lineto stroke" thickness bx by mx my ex ey))))
+
+#(define-markup-command (drawBendArrow layout props
+                          thickness begin-x middle-x end-x begin-y end-y arrow-lx arrow-rx arrow-y outstring)
+   (number? number? number? number? number? number? number? number? number? string?)
+   (interpret-markup layout props
+     (markup #:postscript
+       (ly:format "~f setlinewidth
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        ~f ~f ~f ~f ~f ~f curveto
+                        stroke
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        ~f ~f lineto
+                        closepath fill"
+thickness
+begin-x begin-y
+middle-x begin-y
+middle-x begin-y end-x begin-y end-x arrow-y
+arrow-lx arrow-y
+end-x end-y
+arrow-rx arrow-y)
+       #:hspace 0
+       #:translate (cons (- end-x 1.2) (+ end-y 0.5))
+       #:fontsize -2
+       #:bold
+       ;; changed:
+       ;#:center-column (outstring)
+       outstring
+       )))
+#(define-markup-command (drawHoldBendWithArrow layout props
+                          thickness begin-x begin-y end-x end-y arrow-lx arrow-rx arrow-y outstring)
+   (number? number? number? number? number? number? number? number? string?)
+   (interpret-markup layout props
+     (markup #:postscript
+       (ly:format "~f setlinewidth
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        stroke
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        ~f ~f lineto
+                        closepath fill
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        stroke"
+thickness
+begin-x begin-y
+begin-x arrow-y
+arrow-lx arrow-y
+begin-x end-y
+arrow-rx arrow-y
+begin-x end-y
+end-x end-y)
+       #:hspace 0
+       #:translate (cons (- begin-x 1.2) (+ end-y 0.5))
+       #:fontsize -2
+       ;; Why does it work here??
+       #:bold #:center-column (outstring))))
+
+#(define-markup-command (drawHoldBendArrowOnly layout props
+                          thickness begin-x begin-y end-x end-y arrow-lx arrow-rx arrow-y outstring)
+   (number? number? number? number? number? number? number? number? string?)
+   (interpret-markup layout props
+     (markup #:postscript
+       (ly:format "~f setlinewidth
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        stroke
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        ~f ~f lineto
+                        closepath fill"
+thickness
+begin-x begin-y
+begin-x arrow-y
+arrow-lx arrow-y
+begin-x end-y
+arrow-rx arrow-y)
+       #:hspace 0
+       #:translate (cons (- begin-x 1.2) (+ end-y 0.5))
+       #:fontsize -2
+       ;; Why does it work here??
+       #:bold #:center-column (outstring))))
+
+%% The markup-command 'draw-dashed-line' was implemented with version 2.17.x
+%% TODO: use 'draw-dashed-line' instead. See also 'tie::draw-hold-bend' below.
+#(define-markup-command (drawDashedLine layout props
+                          thickness begin-x end-x line-y)
+   (number? number? number? number?)
+   ;; TODO: draws a full line instead of a dashed line
+   (interpret-markup layout props
+     (markup #:postscript
+       (ly:format "~f setlinewidth
+                        ~f ~f moveto
+                        ~f ~f lineto
+                        stroke"
+thickness begin-x line-y end-x line-y))))
+
+%%% callbacks
+
+#(define (slur::draw-pointed-slur grob)
+   (let* ((control-points (ly:grob-property grob 'control-points))
+          (direction (ly:grob-property grob 'direction))
+          (first-point (car control-points))
+          (second-point (cadr control-points))
+          (third-point (caddr control-points))
+          (forth-point (cadddr control-points))
+          (first-x (+ (car first-point) 0.125)) ;; due to David's proposals
+          (first-y (cdr first-point))
+          (second-x (car second-point))
+          (second-y (cdr second-point))
+          (third-x (car third-point))
+          (third-y (cdr third-point))
+          (forth-x (- (car forth-point) 0.125))
+          (forth-y (cdr forth-point))
+
+          (middle-x (/ (+ third-x second-x) 2))
+          (middle-y (/ (+ third-y second-y) 2)))
+
+     (grob-interpret-markup grob
+       (make-pointedSlur-markup bend-line-thickness
+         first-x first-y middle-x middle-y forth-x forth-y))))
+
+#(define (slur::draw-bend-arrow grob)
+   (let* ((staff-symbol (ly:grob-object grob 'staff-symbol))
+          (line-count (ly:grob-property staff-symbol 'line-count))
+          (staff-space (ly:grob-property staff-symbol 'staff-space))
+          (left-bound (ly:spanner-bound grob LEFT))
+          (right-bound (ly:spanner-bound grob RIGHT))
+          (left-tab-note-head (ly:grob-property left-bound 'cause))
+          (right-tab-note-head (ly:grob-property right-bound 'cause))
+          (control-points (ly:grob-property grob 'control-points))
+          (left-point (car control-points))
+          ;;changed: cadddr changed to last
+          (right-point (last control-points))
+          (left-pitch  (ly:event-property (event-cause left-bound) 'pitch))
+          (right-pitch (ly:event-property (event-cause right-bound) 'pitch))
+          (quarterdiff (- (ly:pitch-quartertones right-pitch)
+                         (ly:pitch-quartertones left-pitch)))
+          (begin-x (car left-point))
+          (begin-y (+ (* (/ (ly:grob-property left-tab-note-head 'staff-position) 2)
+                        staff-space)
+                     y-distance-from-staffline-to-arrow))
+          ;; cdr left-point doesn't work, because invisible stems are included
+          (end-x (car right-point))
+          (end-y (+ (* (/ (- line-count 1) 2) staff-space) y-distance-from-tabstaff-to-arrow-tip))
+          (arrow-lx (- end-x (/ bend-arrowhead-width 2)))
+          (arrow-rx (+ end-x (/ bend-arrowhead-width 2)))
+          (arrow-y (- end-y bend-arrowhead-height))
+          (middle-x (+ begin-x (* bend-arrow-curvature-factor (- end-x begin-x))))
+          (bend-amount (quarterdiff->string quarterdiff)))
+
+     (if (< quarterdiff 0)
+         ;; bend down
+         (let* ((y-offset (cdr (ly:grob-extent left-tab-note-head left-tab-note-head Y)))
+                (temp begin-y))
+           (set! begin-y end-y) ;; swap begin-y/end-y
+           (set! end-y (+ temp y-offset))
+           (set! arrow-y (+ end-y bend-arrowhead-height))
+           (set! bend-amount "")
+           (ly:grob-set-property! right-tab-note-head 'display-cautionary #t)
+           (ly:grob-set-property! right-tab-note-head 'stencil tab-note-head::print))
+         ;; bend up
+         (let* ((x-offset (/ (cdr (ly:grob-extent left-tab-note-head left-tab-note-head X))
+                            2)))
+
+           (set! begin-x (+ begin-x x-offset))
+           (ly:grob-set-property! right-tab-note-head 'transparent #t)))
+
+     ;; draw resulting bend arrow
+     (grob-interpret-markup grob
+       (make-drawBendArrow-markup
+        bend-line-thickness
+        begin-x middle-x end-x begin-y end-y
+        arrow-lx arrow-rx arrow-y
+        bend-amount))))
+
+
+#(define (slur::draw-shifted-bend-arrow grob)
+   (let* ((staff-symbol (ly:grob-object grob 'staff-symbol))
+          (line-count (ly:grob-property staff-symbol 'line-count))
+          (staff-space (ly:grob-property staff-symbol 'staff-space))
+          (left-bound (ly:spanner-bound grob LEFT))
+          (right-bound (ly:spanner-bound grob RIGHT))
+          (left-tab-note-head (ly:grob-property left-bound 'cause))
+          (right-tab-note-head (ly:grob-property right-bound 'cause))
+          (control-points (ly:grob-property grob 'control-points))
+          (left-point (car control-points))
+          (right-point (cadddr control-points))
+          (left-pitch  (ly:event-property (event-cause left-bound) 'pitch))
+          (right-pitch (ly:event-property (event-cause right-bound) 'pitch))
+          (quarterdiff (- (ly:pitch-quartertones right-pitch)
+                         (ly:pitch-quartertones left-pitch)))
+          (begin-x (car left-point))
+          (begin-y (+ (* (/ (ly:grob-property left-tab-note-head 'staff-position) 2)
+                        staff-space)
+                     y-distance-from-tabstaff-to-arrow-tip))
+          ;; cdr left-point doesn't work, because invisible stems are included
+          (end-x (car right-point))
+          (end-y (+ (* (/ (- line-count 1) 2) staff-space) y-distance-from-tabstaff-to-arrow-tip consecutive-bends-arrow-height))
+          (arrow-lx (- end-x (/ bend-arrowhead-width 2)))
+          (arrow-rx (+ end-x (/ bend-arrowhead-width 2)))
+          (arrow-y (- end-y bend-arrowhead-height))
+          (middle-x (+ begin-x (* bend-arrow-curvature-factor (- end-x begin-x))))
+          (bend-amount (quarterdiff->string quarterdiff)))
+     (if (< quarterdiff 0)
+         ;; bend down
+         (let* ((y-offset (cdr (ly:grob-extent left-tab-note-head left-tab-note-head Y)))
+                (temp begin-y))
+
+           (set! begin-y end-y) ;; swap begin-y/end-y
+           (set! end-y (+ temp y-offset))
+           (set! arrow-y (+ end-y bend-arrowhead-height))
+           (set! bend-amount "")
+           (ly:grob-set-property! right-tab-note-head 'stencil
+             (lambda (grob) (parenthesize-tab-note-head grob))))
+         ;; bend up
+         (ly:grob-set-property! right-tab-note-head 'transparent #t))
+     ;; draw resulting bend arrow
+     (grob-interpret-markup grob
+       (make-drawBendArrow-markup
+        bend-line-thickness
+        begin-x middle-x end-x begin-y end-y
+        arrow-lx arrow-rx arrow-y
+        bend-amount))))
+
+#(define (slur::draw-pre-bend-hold grob)
+   (let* ((staff-symbol (ly:grob-object grob 'staff-symbol))
+          (line-count (ly:grob-property staff-symbol 'line-count))
+          (staff-space (ly:grob-property staff-symbol 'staff-space))
+          (left-bound (ly:spanner-bound grob LEFT))
+          (right-bound (ly:spanner-bound grob RIGHT))
+          (left-tab-note-head (ly:grob-property left-bound 'cause))
+          (right-tab-note-head (ly:grob-property right-bound 'cause))
+          (control-points (ly:grob-property grob 'control-points))
+          (left-point (car control-points))
+          (right-point (cadddr control-points))
+          (left-pitch  (ly:event-property (event-cause left-bound) 'pitch))
+          (right-pitch (ly:event-property (event-cause right-bound) 'pitch))
+          (quarterdiff (- (ly:pitch-quartertones right-pitch)
+                         (ly:pitch-quartertones left-pitch)))
+          (begin-x (car left-point))
+          (y-offset (cdr (ly:grob-extent left-tab-note-head left-tab-note-head Y)))
+          (begin-y (+ (* (/ (ly:grob-property left-tab-note-head 'staff-position)
+                           2)
+                        staff-space)
+                     y-offset))
+          ;; cdr left-point doesn't work, because invisible stems are included
+          (end-x (car right-point))
+          (end-y (+ (* (/ (- line-count 1) 2) staff-space) y-distance-from-tabstaff-to-arrow-tip))
+          (arrow-lx (- begin-x (/ bend-arrowhead-width 2)))
+          (arrow-rx (+ begin-x (/ bend-arrowhead-width 2)))
+          (arrow-y (- end-y bend-arrowhead-height))
+          (bend-amount (quarterdiff->string quarterdiff)))
+
+     (ly:grob-set-property! right-tab-note-head 'transparent #t)
+     ;; draw resulting bend arrow
+     (grob-interpret-markup grob
+       (make-drawHoldBendWithArrow-markup
+        bend-line-thickness
+        begin-x begin-y
+        end-x end-y
+        arrow-lx arrow-rx arrow-y
+        bend-amount))))
+
+#(define (slur::draw-pre-bend-only grob)
+   (let* ((staff-symbol (ly:grob-object grob 'staff-symbol))
+          (line-count (ly:grob-property staff-symbol 'line-count))
+          (staff-space (ly:grob-property staff-symbol 'staff-space))
+          (left-bound (ly:spanner-bound grob LEFT))
+          (right-bound (ly:spanner-bound grob RIGHT))
+          (left-tab-note-head (ly:grob-property left-bound 'cause))
+          (right-tab-note-head (ly:grob-property right-bound 'cause))
+          (control-points (ly:grob-property grob 'control-points))
+          (left-point (car control-points))
+          (right-point (cadddr control-points))
+          (left-pitch  (ly:event-property (event-cause left-bound) 'pitch))
+          (right-pitch (ly:event-property (event-cause right-bound) 'pitch))
+          (quarterdiff (- (ly:pitch-quartertones right-pitch)
+                         (ly:pitch-quartertones left-pitch)))
+          (begin-x (car left-point))
+          (y-offset (cdr (ly:grob-extent left-tab-note-head left-tab-note-head Y)))
+          (begin-y (+ (* (/ (ly:grob-property left-tab-note-head 'staff-position)
+                           2)
+                        staff-space)
+                     y-offset))
+          ;; cdr left-point doesn't work, because invisible stems are included
+          (end-x (car right-point))
+          (end-y (+ (* (/ (- line-count 1) 2) staff-space) y-distance-from-tabstaff-to-arrow-tip))
+          (arrow-lx (- begin-x (/ bend-arrowhead-width 2)))
+          (arrow-rx (+ begin-x (/ bend-arrowhead-width 2)))
+          (arrow-y (- end-y bend-arrowhead-height))
+          (bend-amount (quarterdiff->string quarterdiff)))
+
+     (ly:grob-set-property! right-tab-note-head 'transparent #t)
+     ;; draw resulting bend arrow
+     (grob-interpret-markup grob
+       (make-drawHoldBendArrowOnly-markup
+        bend-line-thickness
+        begin-x begin-y
+        end-x end-y
+        arrow-lx arrow-rx arrow-y
+        bend-amount))))
+
+#(define (tie::draw-hold-bend grob)
+   (let* ((staff-symbol (ly:grob-object grob 'staff-symbol))
+          (line-count (ly:grob-property staff-symbol 'line-count))
+          (staff-space (ly:grob-property staff-symbol 'staff-space))
+          (left-tab-note-head (ly:spanner-bound grob LEFT))
+          (right-tab-note-head (ly:spanner-bound grob RIGHT))
+          (control-points (ly:grob-property grob 'control-points))
+          (left-point (car control-points))
+          (right-point (cadddr control-points))
+          (begin-x (car left-point))
+          (end-x (car right-point))
+          (line-y (+ (* (/ (- line-count 1) 2) staff-space) y-distance-from-tabstaff-to-arrow-tip)))
+
+     (ly:grob-set-property! right-tab-note-head 'transparent #t)
+     (grob-interpret-markup grob
+       (make-drawDashedLine-markup
+        bend-line-thickness
+        begin-x end-x line-y)
+       ;; with 2.17.21 one could use:
+       ;(make-translate-markup (cons 0 line-y)
+       ;  (make-override-markup '(on . 0.3)
+       ;    (make-draw-dashed-line-markup
+       ;      (cons end-x 0))))
+       )))
+
+%%% music functions
+
+bendOn =
+#(define-music-function (parser location note) (ly:music?)
+#{
+  \override Voice.Slur #'stencil = #slur::draw-pointed-slur
+  \override TabVoice.Slur #'stencil = #slur::draw-bend-arrow
+  $note \noBreak
+#})
+
+bendOff = {
+  \revert Voice.Slur #'stencil
+  \override TabVoice.Slur #'stencil = #slur::draw-tab-slur
+}
+
+bendGrace =
+#(define-music-function (parser location note) (ly:music?)
+   #{
+     \once \override Voice.Stem #'stencil = #point-stencil
+     \once \override Voice.Flag #'stencil = ##f
+     \once \override Voice.Stem #'direction = #DOWN
+     \once \override Voice.Slur #'direction = #UP
+     \grace #note
+   #})
+
+preBendHold =
+#(define-music-function (parser location note) (ly:music?)
+   #{
+     \once \override TabVoice.Slur #'stencil = #slur::draw-pre-bend-only
+     \once \override TabStaff.ParenthesesItem #'transparent = ##t
+     <>\noBeam \parenthesize #note
+   #})
+
+preBendRelease =
+#(define-music-function (parser location note) (ly:music?)
+   #{
+     \once \override TabVoice.Slur #'stencil = #slur::draw-pre-bend-hold
+     \once \override TabStaff.ParenthesesItem #'transparent = ##t
+     \once \override Voice.Slur #'direction = #DOWN
+     <>\noBeam \parenthesize #note
+   #})
+
+holdBend =
+#(define-music-function (parser location) ()
+   #{
+     \once \override TabVoice.Tie #'stencil = #tie::draw-hold-bend
+   #})
+
+shiftBend = {
+  \once \override TabVoice.Slur #'stencil = #slur::draw-shifted-bend-arrow
+}

--- a/ly/tablature/bending.ily
+++ b/ly/tablature/bending.ily
@@ -1,4 +1,4 @@
-\version "2.16.2" % absolutely necessary!
+\version "2.18.0"
 
 \header {
   oll-title = "Guitar string bending notation"

--- a/ly/tablature/microtones.ily
+++ b/ly/tablature/microtones.ily
@@ -369,6 +369,8 @@ Example: 47/7 -> (6 5/7)"
 %% TODO better coding for all this string->number/number->string
 #(define my-format-tab-note-head
   (lambda (grob)
+    (display (car (last-pair (ly:grob-property grob 'text))))(newline)
+
     (let* ((txt (ly:grob-property grob 'text))
            (nmbr (if (null? txt) "" (car (last-pair txt))))
            (string-nmbr (string->number nmbr)))

--- a/ly/tablature/microtones.ily
+++ b/ly/tablature/microtones.ily
@@ -373,7 +373,9 @@ Example: 47/7 -> (6 5/7)"
 
     (let* ((txt (ly:grob-property grob 'text))
            (nmbr (if (null? txt) "" (car (last-pair txt))))
-           (string-nmbr (string->number nmbr)))
+           (string-nmbr (if (string? nmbr) 
+                            (string->number nmbr)
+                            1)))
      (if (and (string? nmbr) string-nmbr)
          (let* ((val (integer-and-fraction string-nmbr))
                 (fret

--- a/ly/tablature/microtones.ily
+++ b/ly/tablature/microtones.ily
@@ -369,10 +369,15 @@ Example: 47/7 -> (6 5/7)"
 %% TODO better coding for all this string->number/number->string
 #(define my-format-tab-note-head
   (lambda (grob)
-    (display (car (last-pair (ly:grob-property grob 'text))))(newline)
-
     (let* ((txt (ly:grob-property grob 'text))
            (nmbr (if (null? txt) "" (car (last-pair txt))))
+           ; TODO: Please check the following conditional.
+           ; It is a workaround for a change in 2.19.31
+           ; This causes the second-to-last item sometimes 
+           ; not to be a string representation of a number.
+           ; The following conditional is a workaround that 
+           ; seems to successfully suppress the issue - 
+           ; but it seems dubious it is a "sane" cure.
            (string-nmbr (if (string? nmbr) 
                             (string->number nmbr)
                             1)))

--- a/ly/tablature/usage-examples/bends.ly
+++ b/ly/tablature/usage-examples/bends.ly
@@ -4,6 +4,8 @@
 
 \useLibrary Tablature
 \useModule tablature.microtones
+% Workaround for issue #136 at
+% https://github.com/openlilylib/snippets/issues/136
 #(display "")
 \useModule tablature.bending
 
@@ -59,18 +61,20 @@ test = \relative c'' {
   %% that he ties to a note which is bent, but I don't know how (yet).
   \bendGrace c'8 ( \holdBend d2 ) ~ d2 ( c1 )
   c4 ( \shiftBend d) ( e2 )
-  \bendOff
+  
   %% switching bends off works apparently
   c,4 ( d ) f4 ( g )
   a4 ( g ) e\2 ( d )
   %}
 }
 
+
 \markup \wordwrap {
   The coordinates of the point are half-way between the
   second and the third point of the control points for the slur's bezier
   curve.
 }
+
 
 \score {
   <<

--- a/ly/tablature/usage-examples/bends.ly
+++ b/ly/tablature/usage-examples/bends.ly
@@ -3,6 +3,8 @@
 \include "openlilylib"
 
 \useLibrary Tablature
+\useModule tablature.microtones
+#(display "")
 \useModule tablature.bending
 
 % Hack needed until issue #136 is fixed:
@@ -52,10 +54,10 @@ test = \relative c'' {
   \break
   % quarter tone bends are not yet supported as they should be, but
   % the bend amount is calculated correctly ;-)
-  %c,4 ( cih ) c4 ( cisih )
+  c,4 ( cih ) c4 ( cisih )
   %% I hope that in future releases the tie will recognize automagically
   %% that he ties to a note which is bent, but I don't know how (yet).
-  \bendGrace c8 ( \holdBend d2 ) ~ d2 ( c1 )
+  \bendGrace c'8 ( \holdBend d2 ) ~ d2 ( c1 )
   c4 ( \shiftBend d) ( e2 )
   \bendOff
   %% switching bends off works apparently

--- a/ly/tablature/usage-examples/bends.ly
+++ b/ly/tablature/usage-examples/bends.ly
@@ -1,0 +1,88 @@
+\version "2.18.0"
+
+\include "openlilylib"
+
+\useLibrary Tablature
+\useModule tablature.bending
+
+% Hack needed until issue #136 is fixed:
+% https://github.com/openlilylib/openlilylib/issues/136
+#(ly:message "loaded")
+
+\paper {
+  indent = 0
+  ragged-right = ##f
+  ragged-bottom = ##f
+  ragged-last-bottom= ##f
+}
+
+\layout {
+  \context {
+    \Staff
+    \override StringNumber #'stencil = ##f
+    \override VerticalAxisGroup #'default-staff-staff-spacing =
+    #'((basic-distance . 12)
+       (minimum-distance . 12)
+       (padding . 1))
+  }
+}
+
+% TODO: this should be split into separate cases, and
+% comments turned into description markups:
+
+test = \relative c'' {
+  \bendOn
+  % First, some bends to see if they work from the topmost to the lowest string
+  c4 ( d )( c2 )
+  c4\2 ( d\2 )( c2\2 )
+  c4\3 ( des\3 )( c2\3 ) \break
+  c,4\4 ( d\4 )( c2\4 )
+  c4\5 ( d\5 )( c2\5 )
+  c4\6 ( d\6 )( c2\6 ) \break
+  % is the bend amount displayed correctly? (should be ½ in both cases)
+  c4 ( cis) d ( es )
+  % grace notes
+  \bendGrace c8(  d4 )( c4 ) r2
+  % the distinction between \preBendHold and \preBendRelease is not very
+  % elegant here, I hope that there will be a better solution...
+  \bendGrace { \preBendHold c8( } d2)  r2
+  \bendGrace { \preBendRelease c8( d)( } c2)  r2
+  c4 ( es) e\2 ( gis\2 )
+  %%{
+  \break
+  % quarter tone bends are not yet supported as they should be, but
+  % the bend amount is calculated correctly ;-)
+  %c,4 ( cih ) c4 ( cisih )
+  %% I hope that in future releases the tie will recognize automagically
+  %% that he ties to a note which is bent, but I don't know how (yet).
+  \bendGrace c8 ( \holdBend d2 ) ~ d2 ( c1 )
+  c4 ( \shiftBend d) ( e2 )
+  \bendOff
+  %% switching bends off works apparently
+  c,4 ( d ) f4 ( g )
+  a4 ( g ) e\2 ( d )
+  %}
+}
+
+\markup \wordwrap {
+  The coordinates of the point are half-way between the
+  second and the third point of the control points for the slur's bezier
+  curve.
+}
+
+\score {
+  <<
+    \new Staff {
+      \new Voice {
+        \clef "G_8"
+        \test
+      }
+    }
+    \new TabStaff {
+      \new TabVoice {
+        \clef "tab"
+        \test
+      }
+    }
+  >>
+}


### PR DESCRIPTION
I've merely copied and adapted the snippet in `notation-snippets/guitar-string-bending/`.

I have a question regarding version changes.
In the bend.ly example there's a commented line where microtone bendings are used. In order for this to work, I should load also the microtones module for versions below 2.19.31 or change the example for versions >=2.19.31. How to handle such a situation?

By the way, I was not able to load two modules:

```
\useLibrary Tablature
\useModule tablature.bending
\useModule tablature.microtones
```
