### PR TITLE
git-commands: \gitTag command and update version statements

### DIFF
--- a/editorial-tools/git-commands/definitions.ily
+++ b/editorial-tools/git-commands/definitions.ily
@@ -82,6 +82,8 @@ gitParentCommittish = \markup { \gitCommand "rev-parse --short HEAD^1" }
 % Print the oneline commit message of the latest commit
 gitParentCommit = \markup { \gitCommand "log --oneline HEAD~2..HEAD~1" }
 
+% Print the most reachable tag & number of commits since. Fall back to commitish
+gitTag = \markup { \gitCommand "describe --tags --dirty=-modified --always" }
 
 % Print the branch the repository is currently on
 gitBranch = \markup { \gitCommand "rev-parse --abbrev-ref HEAD" }

--- a/editorial-tools/git-commands/definitions.ily
+++ b/editorial-tools/git-commands/definitions.ily
@@ -1,4 +1,4 @@
-\version "2.16.2"
+\version "2.18.2"
 
 \header {
   snippet-title = "Print Git repository information"

--- a/editorial-tools/git-commands/example.ly
+++ b/editorial-tools/git-commands/example.ly
@@ -1,3 +1,5 @@
+\version "2.18.2"
+
 \include "definitions.ily"
 
 \header {

--- a/editorial-tools/git-commands/example.ly
+++ b/editorial-tools/git-commands/example.ly
@@ -67,6 +67,10 @@
 \markup \bold \gitParentCommit
 \markup \vspace #0.5
 
+\markup "Tag:"
+\markup \bold \gitTag
+\markup \vspace #0.5
+
 \markup "Current branch:"
 \markup \bold \gitBranch
 \markup \vspace #0.5


### PR DESCRIPTION
Add `\gitTag` command and example. Update version statements for git-commands to 2.18.2

`\gitTag` prints the most reachable tag. If there have been commits since, a number will be appended to the tag. If there is no tag, it falls back to printing the short commitish.

I have used this previously to keep track of different 'released' versions of the score for a musical whilst things changed during rehearsals. When I wanted to print a new set of scores/parts, I would create a tag named with the date e.g. 2015-12-21, which would be displayed in the header of each page.

If you want to go back to a previous released version, you can just run `git checkout 2015-12-01`, for example, and compile. (I used a Makefile.) For a list of released versions, you can run `git tag`.
