### PR TITLE
[git-commands] adds gitFileRevision

### DIFF
--- a/editorial-tools/git-commands/definitions.ily
+++ b/editorial-tools/git-commands/definitions.ily
@@ -99,7 +99,7 @@ gitRevisionNumber = \markup { \gitCommand "log --oneline | wc -l" }
 gitFileRevision = #(define-markup-command (gitFileRevision layout props file) (markup?)
   (gitCommand-markup layout props
     (string-append (string-append
-              "log --oneline -- \""
+              "log --follow --oneline -- \""
               file)
                "\" | wc -l")))
 

--- a/editorial-tools/git-commands/definitions.ily
+++ b/editorial-tools/git-commands/definitions.ily
@@ -93,6 +93,16 @@ gitBranch = \markup { \gitCommand "rev-parse --abbrev-ref HEAD" }
 % of the counting of merge commits
 gitRevisionNumber = \markup { \gitCommand "log --oneline | wc -l" }
 
+% Print the number of commits to the argument file path
+% that lead to the current commit. This may not be
+% reliable because of the counting of merge commits
+gitFileRevision = #(define-markup-command (gitFileRevision layout props file) (markup?)
+  (gitCommand-markup layout props
+    (string-append (string-append
+              "log --oneline -- \""
+              file)
+               "\" | wc -l")))
+
 % Return ##t if the repository is clean, i.e. if it
 % doesn't have any uncommitted changes
 #(define (gitIsClean)
@@ -107,4 +117,3 @@ gitFullCommit = \markup { \gitCommand "log --pretty=full HEAD^1..HEAD" }
 
 % Print a full diff between current HEAD and the working tree
 gitDiff = \markup { \gitCommand "diff" }
-

--- a/editorial-tools/git-commands/example.ly
+++ b/editorial-tools/git-commands/example.ly
@@ -1,6 +1,7 @@
 \version "2.18.2"
 
 \include "definitions.ily"
+\include "openlilylib"
 
 \header {
   title = "Git repository information"
@@ -77,6 +78,11 @@
 
 \markup "Number of commits on this branch:"
 \markup\bold \gitRevisionNumber
+\markup \vspace #0.5
+
+\markup "Number of commits involving this file:"
+file = \thisFile
+\markup\bold \gitFileRevision \file
 \markup \vspace #0.5
 
 % gitIsClean determines whether the current repository is clean,


### PR DESCRIPTION
Closes issue #145.
This request adds the gitFileRevision command. gitFileRevision outputs the number of changes involving the file of which the path is given as an argument. This function can be used together works well with the \thisFile function in openlilylib, as shown in the added example.

The only thing that would have been better, would be to integrate the `\thisFile` function from the openlilylib in the actual function definition. This would avoid having to use an argument. The only way I found to integrate scheme functions and markup functions was using lilypond code blocks, but than the evaluation of `\thisFile`points to the definitions file.
