### PR TITLE
Compare two values without detour

### DIFF
--- a/notation-snippets/shaping-bezier-curves/shapeII.ily
+++ b/notation-snippets/shaping-bezier-curves/shapeII.ily
@@ -249,7 +249,7 @@ shapeII =
 
        ;; if there are more siblings than specifications,
        ;; reuse last specification for remaining siblings.
-       (if (> (- total-found (length all-specs)) 0)
+       (if (> total-found (length all-specs))
            (append! all-specs
              (list (last all-specs))))
 


### PR DESCRIPTION
The previous code made things unnecessarily complicated by calculating the difference of the two values and comparing it to zero instead of just comparing the values.
