### PR TITLE
hairpin-with-text: retain original height setting

### DIFF
--- a/notation-snippets/hairpin-with-text/definitions.ily
+++ b/notation-snippets/hairpin-with-text/definitions.ily
@@ -23,8 +23,8 @@
 hairpinWithText =
 #(define-music-function (parser location text horiz-align vert-align)
    (markup? number-or-string? number?)
+   (if (> 1 (abs vert-align)) #{ \once \override Hairpin.height = 1.1 #})
    #{
-     \once \override Hairpin.height = #(if (> 1 (abs vert-align)) 1.1 0.6666)
      \once \override Voice.Hairpin.after-line-breaking =
      #(lambda (grob)
         (let* ((stencil (ly:hairpin::print grob))


### PR DESCRIPTION
Previously, the `\hairpinWithText` music function always overrode `Hairpin.height`, reinstating the default value if no text is added inbetween.
This overwrites any settings from style sheets, so we change it to only perform the override if necessary.
