### PR TITLE
add zero width non-joiner between compressed syllables

### DIFF
--- a/notation-snippets/lyric-syllable-magnetic-snap/definitions.ily
+++ b/notation-snippets/lyric-syllable-magnetic-snap/definitions.ily
@@ -183,7 +183,8 @@ collectlyricwordEngraver =
            (syl-a-text (if (markup? syl-a-text) syl-a-text (markup syl-a-text)))
            (syl-b-text (ly:grob-property syl-b 'text))
            (syl-b-text (if (markup? syl-b-text) syl-b-text (markup syl-b-text)))
-           (full-text (make-concat-markup (list syl-a-text syl-b-text))))
+           ; add zero width non-joiner between syllables
+           (full-text (make-concat-markup (list syl-a-text "‌" syl-b-text))))
 
           (set! (ly:grob-property syl-a 'text) full-text)
           (set! (ly:grob-property syl-b 'text) empty-markup)

--- a/notation-snippets/lyric-syllable-magnetic-snap/example.ly
+++ b/notation-snippets/lyric-syllable-magnetic-snap/example.ly
@@ -12,7 +12,8 @@
     \override Lyrics.LyricWord.after-line-breaking = #(lyric-word-compressor 0)
     \override Lyrics.LyricHyphen.minimum-distance = #0
     \override Lyrics.LyricSpace.minimum-distance = #1
-    \repeat unfold 10 { foo }
+    \repeat unfold 3 { foof -- ifi }
+    \repeat unfold 2 { AMA -- VIS }
     \repeat unfold 10 { foo -- \markup \caps bar }
     \repeat unfold 10 { \markup \bold syl -- la -- ble }
     a \markup \with-color #red ran -- \markup \box dom string of mo -- no -- syl -- la -- bic
@@ -32,7 +33,8 @@
     \override Lyrics.LyricWord.after-line-breaking = #(lyric-word-compressor 0.4)
     \override Lyrics.LyricHyphen.minimum-distance = #0
     \override Lyrics.LyricSpace.minimum-distance = #1
-    \repeat unfold 10 { foo }
+    \repeat unfold 3 { foof -- ifi }
+    \repeat unfold 2 { AMA -- VIS }
     \repeat unfold 10 { foo -- \markup \caps bar }
     \repeat unfold 10 { \markup \bold syl -- la -- ble }
     a ran -- \markup \box dom string of


### PR DESCRIPTION
Title says it all - AFAIK, no ligatures should be set across boundaries of syllables (e.g., to mention a German example, in "Kaufleute" no fl-ligature should be used).