### PR TITLE
fix dot problem in merge-rests-engraver

### DIFF
--- a/editorial-tools/merge-rests-engraver/module.ily
+++ b/editorial-tools/merge-rests-engraver/module.ily
@@ -30,10 +30,15 @@
          (stop-translation-timestep . ,(lambda (trans)
                                          (if (and (has-at-least-two
                                                    rests) (all-equal rests rest-same-length))
-                                             (for-each
-                                              (lambda (rest)
-                                                (ly:grob-set-property! rest 'Y-offset 0))
-                                              rests))))
+                                             (begin
+                                              (for-each
+                                               (lambda (rest)
+                                                 (ly:grob-set-property! rest 'Y-offset 0))
+                                               rests)
+                                              (for-each
+                                               (lambda (rest)
+                                                 (ly:grob-set-property! (ly:grob-object rest 'dot) 'dot-count 0))
+                                               (cdr rests))))))
          (acknowledgers
           (rest-interface . ,(lambda (engraver grob source-engraver)
                                (if (eq? 'Rest (assoc-ref


### PR DESCRIPTION
The merge-rests-engraver did not merge the dots of several dotted rests resulting in multiple stacked dots on a single merged rest (cf. #123).
This commit fixes the issue by removing the dots from all merged rests except one.
Since the engraver only merges rests with the same length, it should not matter which rest keeps the dots, so we take the first.