### PR TITLE
Use plumbing commands instead of porcelain

### DIFF
--- a/editorial-tools/git-commands/definitions.ily
+++ b/editorial-tools/git-commands/definitions.ily
@@ -108,7 +108,11 @@ gitFileRevision = #(define-markup-command (gitFileRevision layout props file) (m
 % Return ##t if the repository is clean, i.e. if it
 % doesn't have any uncommitted changes
 #(define (gitIsClean)
-   (eq? "" (strsystem_internal  "git status --porcelain")))
+    (and
+        (eq? 0 (system* "git" "diff-index" "--quiet" "HEAD" "--"))
+        (eq? "" (strsystem_internal  "git ls-files --exclude-standard --others"))
+    )
+)
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Hi! As commit describes, it uses plumbing git commands instead of pocelain because these are safe and their interface is stable (and reliable as result) 