### PR TITLE
Module deprecation, fix link to version-predicates

### DIFF
--- a/deprecate.ily
+++ b/deprecate.ily
@@ -56,3 +56,15 @@ ollSnippetsIncludeHint =
     (ly:message "filename of the loaded file, which is")
     (ly:message "  ~a\n\n" file)))
 
+ollModuleDeprecation =
+#(define-void-function (parser location old-module new-module)
+   (string? string?)
+    (ly:message "\n\nDEPRECATION!\n\n")
+    (ly:message "You have loaded the openLilyLib module\n\n")
+    (ly:message "  ~a\n\n" old-module)
+    (ly:message "The functionality of this module has been moved")
+    (ly:message "or reimplemented in the module\n\n")
+    (ly:message "  ~a\n\n" new-module)
+    (ly:message "Please consider switching to the new module.")
+    (ly:message "Consult the documentation to check whether the new module")
+    (ly:message "can be used in the same way as the old one.\n\n"))

--- a/notation-snippets/shaping-bezier-curves/shapeII/module.ily
+++ b/notation-snippets/shaping-bezier-curves/shapeII/module.ily
@@ -1,5 +1,9 @@
 \version "2.17.26"
-\include "ly/_internal/utilities/lilypond-version-predicates.ily"
+\include "../../../ly/_internal/utilities/lilypond-version-predicates.ily"
+\include "../../../deprecate.ily"
+\ollModuleDeprecation
+"snippets.notation-snippets.shaping-bezier-curves.shapeII"
+"bezier.shapeII"
 
 \header {
   snippet-title = "Improved \shape"


### PR DESCRIPTION
Fixes #171

This commit does two things:
* Change the link to the version-predicates files to a relative
  path from the file, not the root
* Add a deprecation warning and apply it to the shapeII module